### PR TITLE
Added handling of URL 

### DIFF
--- a/DownloaderForReddit/Extractors/ImgurExtractor.py
+++ b/DownloaderForReddit/Extractors/ImgurExtractor.py
@@ -155,6 +155,8 @@ class ImgurExtractor(BaseExtractor):
         domain, album_id = self.url.rsplit('/', 1)
         for pic in self.client.get_album_images(album_id):
             url = pic.link
+            if('?' in url):
+                url = url[:url.find('?')]
             address, extension = url.rsplit('.', 1)
             file_name = self.get_filename(album_id)
             if pic.animated:


### PR DESCRIPTION
I discovered that the Imgur API will occasionally append an extraneous ?1 query to the end of the URL for images in an album. 

This commit handles this case. 