### PR TITLE
Added support for Gfycat tagged URLs

### DIFF
--- a/DownloaderForReddit/Extractors/GfycatExtractor.py
+++ b/DownloaderForReddit/Extractors/GfycatExtractor.py
@@ -52,6 +52,7 @@ class GfycatExtractor(BaseExtractor):
 
     def extract_single(self):
         domain, gif_id = self.url.rsplit('/', 1)
+        gif_id = gif_id.split('-',1)[0]
         gfy_json = self.get_json(self.api_caller + gif_id)
         gfy_url = gfy_json.get('gfyItem').get('webmUrl')
         file_name = self.get_filename(gif_id)

--- a/Tests/MockObjects/MockObjects.py
+++ b/Tests/MockObjects/MockObjects.py
@@ -73,6 +73,15 @@ def get_mock_post_gfycat():
     post.url = 'https://gfycat.com/KindlyElderlyCony'
     return post
 
+def get_mock_post_gfycat_direct():
+    post = get_generic_mock_post()
+    post.url = 'https://giant.gfycat.com/KindlyElderlyCony.webm'
+    return post
+
+def get_mock_post_gfycat_tagged():
+    post = get_generic_mock_post()
+    post.url = 'https://gfycat.com/KeenGargantuanDoe-horses'
+    return post
 
 def get_mock_post_vidble():
     post = get_generic_mock_post()

--- a/Tests/MockObjects/MockObjects.py
+++ b/Tests/MockObjects/MockObjects.py
@@ -80,7 +80,7 @@ def get_mock_post_gfycat_direct():
 
 def get_mock_post_gfycat_tagged():
     post = get_generic_mock_post()
-    post.url = 'https://gfycat.com/KeenGargantuanDoe-horses'
+    post.url = 'https://gfycat.com/anchoredenchantedamericanriverotter-saturday-exhausted-weekend-kitten-pissed'
     return post
 
 def get_mock_post_vidble():

--- a/Tests/UnitTests/Extractors/test_GfycatExtractor.py
+++ b/Tests/UnitTests/Extractors/test_GfycatExtractor.py
@@ -23,11 +23,11 @@ class TestGfycatExtractor(unittest.TestCase):
 
     @patch('DownloaderForReddit.Extractors.GfycatExtractor.get_json')
     def test_extract_single_tagged(self, j_mock):
-        dir_url = 'https://giant.gfycat.com/KeenGargantuanDoe.webm'
+        dir_url = 'https://giant.gfycat.com/anchoredenchantedamericanriverotter.webm'
         j_mock.return_value = {'gfyItem': {'webmUrl': dir_url}}
         ge = GfycatExtractor(MockObjects.get_mock_post_gfycat_tagged(), MockObjects.get_blank_user())
         ge.extract_single()
-        j_mock.assert_called_with('https://api.gfycat.com/v1/gfycats/KeenGargantuanDoe')
+        j_mock.assert_called_with('https://api.gfycat.com/v1/gfycats/anchoredenchantedamericanriverotter')
         self.check_output_tagged(ge, dir_url)
 
     def test_direct_extraction(self):
@@ -74,6 +74,6 @@ class TestGfycatExtractor(unittest.TestCase):
         self.assertEqual('Picture(s)', content.post_title)
         self.assertEqual('Pics', content.subreddit)
         self.assertEqual(1521473630, content.date_created)
-        self.assertEqual('C:/Users/Gorgoth/Downloads/JohnEveryman/KeenGargantuanDoe.webm', content.filename)
+        self.assertEqual('C:/Users/Gorgoth/Downloads/JohnEveryman/anchoredenchantedamericanriverotter.webm', content.filename)
         self.assertTrue(len(ge.failed_extract_posts) == 0)
 

--- a/Tests/UnitTests/Extractors/test_GfycatExtractor.py
+++ b/Tests/UnitTests/Extractors/test_GfycatExtractor.py
@@ -13,7 +13,7 @@ class TestGfycatExtractor(unittest.TestCase):
         Injector.settings_manager = MockSettingsManager()
 
     @patch('DownloaderForReddit.Extractors.GfycatExtractor.get_json')
-    def test_extract_single(self, j_mock):
+    def test_extract_single_untagged(self, j_mock):
         dir_url = 'https://giant.gfycat.com/KindlyElderlyCony.webm'
         j_mock.return_value = {'gfyItem': {'webmUrl': dir_url}}
         ge = GfycatExtractor(MockObjects.get_mock_post_gfycat(), MockObjects.get_blank_user())
@@ -21,9 +21,17 @@ class TestGfycatExtractor(unittest.TestCase):
         j_mock.assert_called_with('https://api.gfycat.com/v1/gfycats/KindlyElderlyCony')
         self.check_output(ge, dir_url)
 
+    @patch('DownloaderForReddit.Extractors.GfycatExtractor.get_json')
+    def test_extract_single_tagged(self, j_mock):
+        dir_url = 'https://giant.gfycat.com/KeenGargantuanDoe.webm'
+        j_mock.return_value = {'gfyItem': {'webmUrl': dir_url}}
+        ge = GfycatExtractor(MockObjects.get_mock_post_gfycat_tagged(), MockObjects.get_blank_user())
+        ge.extract_single()
+        j_mock.assert_called_with('https://api.gfycat.com/v1/gfycats/KeenGargantuanDoe')
+        self.check_output_tagged(ge, dir_url)
+
     def test_direct_extraction(self):
-        post = MockObjects.get_mock_post_gfycat()
-        post.url = post.url + '.webm'
+        post = MockObjects.get_mock_post_gfycat_direct()
         ge = GfycatExtractor(post, MockObjects.get_blank_user())
         ge.extract_direct_link()
         self.check_output(ge, post.url)
@@ -32,7 +40,6 @@ class TestGfycatExtractor(unittest.TestCase):
     def test_extract_content_assignment_single(self, es_mock):
         ge = GfycatExtractor(MockObjects.get_mock_post_gfycat(), MockObjects.get_blank_user())
         ge.extract_content()
-
         es_mock.assert_called()
 
     @patch('DownloaderForReddit.Extractors.GfycatExtractor.extract_direct_link')
@@ -60,3 +67,13 @@ class TestGfycatExtractor(unittest.TestCase):
         self.assertEqual(1521473630, content.date_created)
         self.assertEqual('C:/Users/Gorgoth/Downloads/JohnEveryman/KindlyElderlyCony.webm', content.filename)
         self.assertTrue(len(ge.failed_extract_posts) == 0)
+
+    def check_output_tagged(self, ge, url):
+        content = ge.extracted_content[0]
+        self.assertEqual(url, content.url)
+        self.assertEqual('Picture(s)', content.post_title)
+        self.assertEqual('Pics', content.subreddit)
+        self.assertEqual(1521473630, content.date_created)
+        self.assertEqual('C:/Users/Gorgoth/Downloads/JohnEveryman/KeenGargantuanDoe.webm', content.filename)
+        self.assertTrue(len(ge.failed_extract_posts) == 0)
+


### PR DESCRIPTION
Gfycat URLs can have tags in them in the form 
`https://gfycat.com/[gfyid]-[tag1]-[tag2]-[tag3]-...`

This pull request handles these tagged URLs. 