### PR TITLE
Praw submission extractor rework

### DIFF
--- a/DownloaderForReddit/Core/PostFilter.py
+++ b/DownloaderForReddit/Core/PostFilter.py
@@ -38,8 +38,7 @@ class PostFilter:
         :param reddit_object: The reddit object to which the post belongs.
         :return: True or False depending on if the post passed the filter criteria.
         """
-        return self.score_filter(post) and self.nsfw_filter(post, reddit_object) and \
-               self.date_filter(post, reddit_object)
+        return self.score_filter(post) and self.nsfw_filter(post, reddit_object)
 
     def score_filter(self, post):
         """

--- a/Tests/MockObjects/MockObjects.py
+++ b/Tests/MockObjects/MockObjects.py
@@ -124,3 +124,10 @@ class MockPrawPost:
 
         self.id = 'abcde'
         self.domain = 'reddit'
+
+
+class MockPrawSubreddit:
+
+    def __init__(self, **kwargs):
+        self.name = kwargs.get('name', None)
+        self.display_name = self.name

--- a/Tests/MockObjects/MockObjects.py
+++ b/Tests/MockObjects/MockObjects.py
@@ -109,7 +109,7 @@ def get_mock_post_reddit_video():
 class MockPrawPost:
 
     def __init__(self, url=None, author=None, title=None, subreddit=None, created=None, score=None, over_18=None,
-                 is_video=False, crosspost_parent=None, media=None):
+                 is_video=False, crosspost_parent=None, media=None, stickied=False):
         self.url = url
         self.author = author
         self.title = title
@@ -120,6 +120,7 @@ class MockPrawPost:
         self.is_video = is_video
         self.crosspost_parent = crosspost_parent
         self.media = media
+        self.stickied = stickied
 
         self.id = 'abcde'
         self.domain = 'reddit'

--- a/Tests/UnitTests/Core/test_DownloadRunner.py
+++ b/Tests/UnitTests/Core/test_DownloadRunner.py
@@ -1,0 +1,85 @@
+from datetime import datetime, timedelta
+from unittest import TestCase
+from unittest.mock import patch
+
+from DownloaderForReddit.Core.DownloadRunner import DownloadRunner
+from DownloaderForReddit.Utils import Injector, RedditUtils
+from Tests.MockObjects.MockSettingsManager import MockSettingsManager
+from Tests.MockObjects.MockObjects import MockPrawPost, get_blank_user
+
+
+class TestDownloadRunner(TestCase):
+
+    def setUp(self):
+        Injector.settings_manager = MockSettingsManager()
+        RedditUtils.reddit_instance = None
+
+    @patch('DownloaderForReddit.Core.DownloadRunner.DownloadRunner.get_raw_submissions')
+    @patch('DownloaderForReddit.Core.DownloadRunner.DownloadRunner.start_downloader')
+    @patch('DownloaderForReddit.Core.DownloadRunner.DownloadRunner.start_extractor')
+    def test_get_submissions_with_old_stickied_posts(self, start_extractor, start_downloader, get_raw_submissions):
+        reddit_user = get_blank_user()
+        reddit_user.date_limit = datetime.now() - timedelta(days=10)
+        mock_posts_list = []
+        for x in range(2):
+            mock_posts_list.append(MockPrawPost(created=datetime.now() - timedelta(days=100), stickied=True))
+        for x in range(2, 20):
+            mock_posts_list.append(MockPrawPost(created=datetime.now() - timedelta(days=x)))
+        get_raw_submissions.return_value = self.submission_generator(mock_posts_list)
+        self.assertEqual(20, len(mock_posts_list))
+
+        download_runner = DownloadRunner(None, None, None, None)
+        submissions = download_runner.get_submissions(None, reddit_user)
+
+        self.assertEqual(8, len(submissions))
+        for sub in submissions:
+            self.assertGreater(sub.created, reddit_user.date_limit)
+            self.assertFalse(sub.stickied)
+
+    @patch('DownloaderForReddit.Core.DownloadRunner.DownloadRunner.get_raw_submissions')
+    @patch('DownloaderForReddit.Core.DownloadRunner.DownloadRunner.start_downloader')
+    @patch('DownloaderForReddit.Core.DownloadRunner.DownloadRunner.start_extractor')
+    def test_get_submissions_with_new_stickied_posts(self, start_extractor, start_downloader, get_raw_submissions):
+        reddit_user = get_blank_user()
+        reddit_user.date_limit = datetime.now() - timedelta(days=10)
+        mock_posts_list = []
+        for x in range(2):
+            mock_posts_list.append(MockPrawPost(created=datetime.now() - timedelta(days=x), stickied=True))
+        for x in range(2, 20):
+            mock_posts_list.append(MockPrawPost(created=datetime.now() - timedelta(days=x)))
+        get_raw_submissions.return_value = self.submission_generator(mock_posts_list)
+        self.assertEqual(20, len(mock_posts_list))
+
+        download_runner = DownloadRunner(None, None, None, None)
+        submissions = download_runner.get_submissions(None, reddit_user)
+
+        self.assertEqual(10, len(submissions))
+        stickied = 0
+        for sub in submissions:
+            self.assertGreater(sub.created, reddit_user.date_limit)
+            if sub.stickied:
+                stickied += 1
+        self.assertEqual(2, stickied)
+
+    @patch('DownloaderForReddit.Core.DownloadRunner.DownloadRunner.get_raw_submissions')
+    @patch('DownloaderForReddit.Core.DownloadRunner.DownloadRunner.start_downloader')
+    @patch('DownloaderForReddit.Core.DownloadRunner.DownloadRunner.start_extractor')
+    def test_get_submissions_with_no_stickied_posts(self, start_extractor, start_downloader, get_raw_submissions):
+        reddit_user = get_blank_user()
+        reddit_user.date_limit = datetime.now() - timedelta(days=10)
+        mock_posts_list = []
+        for x in range(20):
+            mock_posts_list.append(MockPrawPost(created=datetime.now() - timedelta(days=x)))
+        get_raw_submissions.return_value = self.submission_generator(mock_posts_list)
+        self.assertEqual(20, len(mock_posts_list))
+
+        download_runner = DownloadRunner(None, None, None, None)
+        submissions = download_runner.get_submissions(None, reddit_user)
+
+        self.assertEqual(10, len(submissions))
+        for sub in submissions:
+            self.assertGreater(sub.created, reddit_user.date_limit)
+
+    def submission_generator(self, post_list):
+        for post in post_list:
+            yield post

--- a/Tests/UnitTests/Core/test_DownloadRunner.py
+++ b/Tests/UnitTests/Core/test_DownloadRunner.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 from DownloaderForReddit.Core.DownloadRunner import DownloadRunner
 from DownloaderForReddit.Utils import Injector, RedditUtils
 from Tests.MockObjects.MockSettingsManager import MockSettingsManager
-from Tests.MockObjects.MockObjects import MockPrawPost, get_blank_user
+from Tests.MockObjects.MockObjects import MockPrawPost, MockPrawSubreddit, get_blank_user
 
 
 class TestDownloadRunner(TestCase):
@@ -77,6 +77,98 @@ class TestDownloadRunner(TestCase):
         submissions = download_runner.get_submissions(None, reddit_user)
 
         self.assertEqual(10, len(submissions))
+        for sub in submissions:
+            self.assertGreater(sub.created, reddit_user.date_limit)
+
+    @patch('DownloaderForReddit.Core.DownloadRunner.DownloadRunner.get_raw_submissions')
+    @patch('DownloaderForReddit.Core.DownloadRunner.DownloadRunner.start_downloader')
+    @patch('DownloaderForReddit.Core.DownloadRunner.DownloadRunner.start_extractor')
+    def test_get_submissions_with_old_stickied_posts_subreddits_filtered(self, start_extractor, start_downloader,
+                                                                         get_raw_submissions):
+        allowed_subreddit = MockPrawSubreddit(name='allowed')
+        forbidden_subreddit = MockPrawSubreddit(name='forbidden')
+        reddit_user = get_blank_user()
+        reddit_user.date_limit = datetime.now() - timedelta(days=20)
+        mock_posts_list = []
+        for x in range(2):
+            mock_posts_list.append(MockPrawPost(created=datetime.now() - timedelta(days=100), stickied=True,
+                                                subreddit=allowed_subreddit))
+        for x in range(2, 18):
+            mock_posts_list.append(MockPrawPost(created=datetime.now() - timedelta(days=x),
+                                                subreddit=allowed_subreddit))
+        for x in range(18, 30):
+            mock_posts_list.append(MockPrawPost(created=datetime.now() - timedelta(days=x),
+                                                subreddit=forbidden_subreddit))
+        get_raw_submissions.return_value = self.submission_generator(mock_posts_list)
+        self.assertEqual(30, len(mock_posts_list))
+
+        download_runner = DownloadRunner(None, None, None, None)
+        download_runner.validated_subreddits.append(allowed_subreddit.display_name)
+        submissions = download_runner.get_submissions(None, reddit_user, subreddit_filter=True)
+
+        self.assertEqual(16, len(submissions))
+        for sub in submissions:
+            self.assertGreater(sub.created, reddit_user.date_limit)
+            self.assertFalse(sub.stickied)
+
+    @patch('DownloaderForReddit.Core.DownloadRunner.DownloadRunner.get_raw_submissions')
+    @patch('DownloaderForReddit.Core.DownloadRunner.DownloadRunner.start_downloader')
+    @patch('DownloaderForReddit.Core.DownloadRunner.DownloadRunner.start_extractor')
+    def test_get_submissions_with_new_stickied_posts_subreddits_filtered(self, start_extractor, start_downloader,
+                                                                         get_raw_submissions):
+        allowed_subreddit = MockPrawSubreddit(name='allowed')
+        forbidden_subreddit = MockPrawSubreddit(name='forbidden')
+        reddit_user = get_blank_user()
+        reddit_user.date_limit = datetime.now() - timedelta(days=20)
+        mock_posts_list = []
+        for x in range(2):
+            mock_posts_list.append(MockPrawPost(created=datetime.now() - timedelta(days=x), stickied=True,
+                                                subreddit=allowed_subreddit))
+        for x in range(2, 18):
+            mock_posts_list.append(MockPrawPost(created=datetime.now() - timedelta(days=x),
+                                                subreddit=allowed_subreddit))
+        for x in range(18, 30):
+            mock_posts_list.append(MockPrawPost(created=datetime.now() - timedelta(days=x),
+                                                subreddit=forbidden_subreddit))
+        get_raw_submissions.return_value = self.submission_generator(mock_posts_list)
+        self.assertEqual(30, len(mock_posts_list))
+
+        download_runner = DownloadRunner(None, None, None, None)
+        download_runner.validated_subreddits.append(allowed_subreddit.display_name)
+        submissions = download_runner.get_submissions(None, reddit_user, subreddit_filter=True)
+
+        self.assertEqual(18, len(submissions))
+        stickied = 0
+        for sub in submissions:
+            self.assertGreater(sub.created, reddit_user.date_limit)
+            if sub.stickied:
+                stickied += 1
+        self.assertEqual(2, stickied)
+
+    @patch('DownloaderForReddit.Core.DownloadRunner.DownloadRunner.get_raw_submissions')
+    @patch('DownloaderForReddit.Core.DownloadRunner.DownloadRunner.start_downloader')
+    @patch('DownloaderForReddit.Core.DownloadRunner.DownloadRunner.start_extractor')
+    def test_get_submissions_with_old_stickied_posts_subreddits_filtered(self, start_extractor, start_downloader,
+                                                                         get_raw_submissions):
+        allowed_subreddit = MockPrawSubreddit(name='allowed')
+        forbidden_subreddit = MockPrawSubreddit(name='forbidden')
+        reddit_user = get_blank_user()
+        reddit_user.date_limit = datetime.now() - timedelta(days=20)
+        mock_posts_list = []
+        for x in range(18):
+            mock_posts_list.append(MockPrawPost(created=datetime.now() - timedelta(days=x),
+                                                subreddit=allowed_subreddit))
+        for x in range(18, 30):
+            mock_posts_list.append(MockPrawPost(created=datetime.now() - timedelta(days=x),
+                                                subreddit=forbidden_subreddit))
+        get_raw_submissions.return_value = self.submission_generator(mock_posts_list)
+        self.assertEqual(30, len(mock_posts_list))
+
+        download_runner = DownloadRunner(None, None, None, None)
+        download_runner.validated_subreddits.append(allowed_subreddit.display_name)
+        submissions = download_runner.get_submissions(None, reddit_user, subreddit_filter=True)
+
+        self.assertEqual(18, len(submissions))
         for sub in submissions:
             self.assertGreater(sub.created, reddit_user.date_limit)
 


### PR DESCRIPTION
Rework the method to extract praw submissions from the praw submission generator.

The old method had to take in every submission from the praw submission generator, then exclude submissions by date.  For previously downloaded users with long post histories this, could be a very time consuming task made unnecessary if only a few new posts had been made since last download.

This rework uses the generator more efficiently to increase the extraction speed.  After each submission is yielded from the generator, the submission date is checked, and if the date is out of the acceptable range the generator iteration is broken and the application proceeds with the next step.

In some tests this sped extraction up by as much as 85%.