### PR TITLE
Decoupled thread count from number of cores

### DIFF
--- a/DownloaderForReddit/GUI/DownloaderForRedditSettingsGUI.py
+++ b/DownloaderForReddit/GUI/DownloaderForRedditSettingsGUI.py
@@ -155,7 +155,8 @@ class RedditDownloaderSettingsGUI(QtWidgets.QDialog, Ui_SettingsGUI):
         self.name_downloads_by_combo.setCurrentText(self.settings_manager.name_downloads_by)
 
         self.thread_limit_spinbox.setValue(self.settings_manager.max_download_thread_count)
-        self.thread_limit_spinbox.setMaximum(QtCore.QThread.idealThreadCount())
+        self.thread_limit_spinbox.setMaximum(64)
+        self.thread_limit_spinbox.setMinimum(1)
 
         self.save_undownloaded_content_checkbox.setChecked(self.settings_manager.save_undownloaded_content)
 


### PR DESCRIPTION
On Windows, `QtCore.QThread.idealThreadCount()` simply returns the number of logical cores on your computer. However, downloading things is an IO-bound, not CPU bound task. In particular, it is limited by the TCP bandwidth-delay-product, which is why download accelerators demonstrate a speedup with multi-threaded downloading. 

In my experiments, I found that increasing the number of threads from 8 to 64 beyond the number of CPU cores increased my mid-extraction bandwidth utilization from 60 Mbps to 99.5 Mbps on a 100 Mbps Ethernet connection when downloading from Eurome. 