### PR TITLE
Duplicate file name fix

### DIFF
--- a/Tests/UnitTests/Extractors/test_DirectExtractor.py
+++ b/Tests/UnitTests/Extractors/test_DirectExtractor.py
@@ -23,4 +23,4 @@ class TestDirectExtractor(unittest.TestCase):
         self.assertEqual('Picture(s)', content.post_title)
         self.assertEqual('Pics', content.subreddit)
         self.assertEqual(1521473630, content.date_created)
-        self.assertEqual('C:/Users/Gorgoth/Downloads/JohnEveryman/3jfd9nlksd.jpg', content.filename)
+        self.assertEqual('C:/Users/Gorgoth/Downloads/JohnEveryman/3jfd9nlksd.jpg', content.make_filename())

--- a/Tests/UnitTests/Extractors/test_GfycatExtractor.py
+++ b/Tests/UnitTests/Extractors/test_GfycatExtractor.py
@@ -65,7 +65,7 @@ class TestGfycatExtractor(unittest.TestCase):
         self.assertEqual('Picture(s)', content.post_title)
         self.assertEqual('Pics', content.subreddit)
         self.assertEqual(1521473630, content.date_created)
-        self.assertEqual('C:/Users/Gorgoth/Downloads/JohnEveryman/KindlyElderlyCony.webm', content.filename)
+        self.assertEqual('C:/Users/Gorgoth/Downloads/JohnEveryman/KindlyElderlyCony.webm', content.make_filename())
         self.assertTrue(len(ge.failed_extract_posts) == 0)
 
     def check_output_tagged(self, ge, url):
@@ -74,6 +74,7 @@ class TestGfycatExtractor(unittest.TestCase):
         self.assertEqual('Picture(s)', content.post_title)
         self.assertEqual('Pics', content.subreddit)
         self.assertEqual(1521473630, content.date_created)
-        self.assertEqual('C:/Users/Gorgoth/Downloads/JohnEveryman/anchoredenchantedamericanriverotter.webm', content.filename)
+        self.assertEqual('C:/Users/Gorgoth/Downloads/JohnEveryman/anchoredenchantedamericanriverotter.webm',
+                         content.make_filename())
         self.assertTrue(len(ge.failed_extract_posts) == 0)
 

--- a/Tests/UnitTests/Extractors/test_ImgurExtractor.py
+++ b/Tests/UnitTests/Extractors/test_ImgurExtractor.py
@@ -48,7 +48,7 @@ class TestImgurExtractor(unittest.TestCase):
         for con in content_list:
             if con.url not in self.url_extract_dict['ALBUM']:
                 return False
-            if not con.filename.startswith('C:/Users/Gorgoth/Downloads/JohnEveryman/') or con.file_ext != '.jpg' or \
+            if not con.make_filename().startswith('C:/Users/Gorgoth/Downloads/JohnEveryman/') or con.file_ext != '.jpg' or \
                     int(con.number_in_seq) != count:
                 return False
             count += 1
@@ -69,7 +69,7 @@ class TestImgurExtractor(unittest.TestCase):
         for con in content_list:
             if con.url not in self.make_gif_list(self.url_extract_dict['ALBUM']):
                 return False
-            if not con.filename.startswith('C:/Users/Gorgoth/Downloads/JohnEveryman/') or con.file_ext != '.mp4' or \
+            if not con.make_filename().startswith('C:/Users/Gorgoth/Downloads/JohnEveryman/') or con.file_ext != '.mp4' or \
                     int(con.number_in_seq) != count:
                 return False
             count += 1
@@ -86,7 +86,7 @@ class TestImgurExtractor(unittest.TestCase):
         self.assertEqual('Picture(s)', content.post_title)
         self.assertEqual('Pics', content.subreddit)
         self.assertEqual(1521473630, content.date_created)
-        self.assertEqual('C:/Users/Gorgoth/Downloads/JohnEveryman/fb2yRj0.jpg', content.filename)
+        self.assertEqual('C:/Users/Gorgoth/Downloads/JohnEveryman/fb2yRj0.jpg', content.make_filename())
         self.assertTrue(len(ie.failed_extract_posts) == 0)
 
     @patch('DownloaderForReddit.Utils.ImgurUtils.imgur_client')
@@ -101,7 +101,7 @@ class TestImgurExtractor(unittest.TestCase):
         self.assertEqual('Pics', content.subreddit)
         self.assertEqual('.mp4', content.file_ext)
         self.assertEqual(1521473630, content.date_created)
-        self.assertEqual('C:/Users/Gorgoth/Downloads/JohnEveryman/fb2yRj0.mp4', content.filename)
+        self.assertEqual('C:/Users/Gorgoth/Downloads/JohnEveryman/fb2yRj0.mp4', content.make_filename())
         self.assertTrue(len(ie.failed_extract_posts) == 0)
 
     @patch('DownloaderForReddit.Utils.ImgurUtils.imgur_client')
@@ -116,7 +116,7 @@ class TestImgurExtractor(unittest.TestCase):
         self.assertEqual('Pics', content.subreddit)
         self.assertEqual('.jpg', content.file_ext)
         self.assertEqual(1521473630, content.date_created)
-        self.assertEqual('C:/Users/Gorgoth/Downloads/JohnEveryman/fb2yRj0.jpg', content.filename)
+        self.assertEqual('C:/Users/Gorgoth/Downloads/JohnEveryman/fb2yRj0.jpg', content.make_filename())
         self.assertTrue(len(ie.failed_extract_posts) == 0)
 
     @patch('DownloaderForReddit.Utils.ImgurUtils.imgur_client')
@@ -131,7 +131,7 @@ class TestImgurExtractor(unittest.TestCase):
         self.assertEqual('Pics', content.subreddit)
         self.assertEqual('.mp4', content.file_ext)
         self.assertEqual(1521473630, content.date_created)
-        self.assertEqual('C:/Users/Gorgoth/Downloads/JohnEveryman/fb2yRj0gif.mp4', content.filename)
+        self.assertEqual('C:/Users/Gorgoth/Downloads/JohnEveryman/fb2yRj0gif.mp4', content.make_filename())
         self.assertTrue(len(ie.failed_extract_posts) == 0)
 
     @patch('DownloaderForReddit.Utils.ImgurUtils.imgur_client')
@@ -153,7 +153,7 @@ class TestImgurExtractor(unittest.TestCase):
         self.assertEqual('Pics', content.subreddit)
         self.assertEqual('.jpg', content.file_ext)
         self.assertEqual(1521473630, content.date_created)
-        self.assertEqual('C:/Users/Gorgoth/Downloads/JohnEveryman/fb2yRj0.jpg', content.filename)
+        self.assertEqual('C:/Users/Gorgoth/Downloads/JohnEveryman/fb2yRj0.jpg', content.make_filename())
         self.assertTrue(len(ie.failed_extract_posts) == 0)
 
     @patch('DownloaderForReddit.Utils.ImgurUtils.imgur_client')
@@ -168,7 +168,7 @@ class TestImgurExtractor(unittest.TestCase):
         self.assertEqual('Pics', content.subreddit)
         self.assertEqual('.mp4', content.file_ext)
         self.assertEqual(1521473630, content.date_created)
-        self.assertEqual('C:/Users/Gorgoth/Downloads/JohnEveryman/fb2yRj0gif.mp4', content.filename)
+        self.assertEqual('C:/Users/Gorgoth/Downloads/JohnEveryman/fb2yRj0gif.mp4', content.make_filename())
         self.assertTrue(len(ie.failed_extract_posts) == 0)
 
     @patch('DownloaderForReddit.Utils.ImgurUtils.imgur_client')

--- a/Tests/UnitTests/Extractors/test_RedditVideoExtractor.py
+++ b/Tests/UnitTests/Extractors/test_RedditVideoExtractor.py
@@ -27,7 +27,7 @@ class TestRedditVideoExtractor(unittest.TestCase):
         self.assertEqual(fallback_url, content.url)
         self.assertEqual('PublicFreakout', content.subreddit)
         self.assertEqual('Reddit Video Broh', content.post_title)
-        self.assertEqual('C:/Users/Gorgoth/Downloads/JohnEveryman/abcde.mp4', content.filename)
+        self.assertEqual('C:/Users/Gorgoth/Downloads/JohnEveryman/abcde.mp4', content.make_filename())
 
         self.assertEqual(0, len(re.failed_extract_posts))
         self.assertEqual(0, len(VideoMerger.videos_to_merge))
@@ -46,12 +46,12 @@ class TestRedditVideoExtractor(unittest.TestCase):
         vid_content = re.extracted_content[0]
         self.assertEqual(fallback_url, vid_content.url)
         self.assertEqual('PublicFreakout', vid_content.subreddit)
-        self.assertEqual('C:/Users/Gorgoth/Downloads/JohnEveryman/abcde(video).mp4', vid_content.filename)
+        self.assertEqual('C:/Users/Gorgoth/Downloads/JohnEveryman/abcde(video).mp4', vid_content.make_filename())
 
         audio_content = re.extracted_content[1]
         self.assertEqual(post.url + '/audio', audio_content.url)
         self.assertEqual('PublicFreakout', audio_content.subreddit)
-        self.assertEqual('C:/Users/Gorgoth/Downloads/JohnEveryman/abcde(audio).mp3', audio_content.filename)
+        self.assertEqual('C:/Users/Gorgoth/Downloads/JohnEveryman/abcde(audio).mp3', audio_content.make_filename())
 
         self.assertEqual(0, len(re.failed_extract_posts))
         self.assertEqual(1, len(VideoMerger.videos_to_merge))
@@ -82,12 +82,12 @@ class TestRedditVideoExtractor(unittest.TestCase):
         vid_content = re.extracted_content[0]
         self.assertEqual(fallback_url, vid_content.url)
         self.assertEqual('PublicFreakout', vid_content.subreddit)
-        self.assertEqual('C:/Users/Gorgoth/Downloads/JohnEveryman/abcde(video).mp4', vid_content.filename)
+        self.assertEqual('C:/Users/Gorgoth/Downloads/JohnEveryman/abcde(video).mp4', vid_content.make_filename())
 
         audio_content = re.extracted_content[1]
         self.assertEqual(parent_post.url + '/audio', audio_content.url)
         self.assertEqual('PublicFreakout', audio_content.subreddit)
-        self.assertEqual('C:/Users/Gorgoth/Downloads/JohnEveryman/abcde(audio).mp3', audio_content.filename)
+        self.assertEqual('C:/Users/Gorgoth/Downloads/JohnEveryman/abcde(audio).mp3', audio_content.make_filename())
 
         self.assertEqual(0, len(re.failed_extract_posts))
         self.assertEqual(1, len(VideoMerger.videos_to_merge))
@@ -108,7 +108,7 @@ class TestRedditVideoExtractor(unittest.TestCase):
         vid_content = re.extracted_content[0]
         self.assertEqual(fallback_url, vid_content.url)
         self.assertEqual('PublicFreakout', vid_content.subreddit)
-        self.assertEqual('C:/Users/Gorgoth/Downloads/JohnEveryman/abcde(video).mp4', vid_content.filename)
+        self.assertEqual('C:/Users/Gorgoth/Downloads/JohnEveryman/abcde(video).mp4', vid_content.make_filename())
 
         self.assertEqual(1, len(re.failed_extract_posts))
         self.assertEqual(0, len(VideoMerger.videos_to_merge))

--- a/Tests/UnitTests/Extractors/test_VidbleExtractor.py
+++ b/Tests/UnitTests/Extractors/test_VidbleExtractor.py
@@ -102,14 +102,14 @@ class TestVidbleExtractor(unittest.TestCase):
             self.assertEqual(1521473630, content.date_created)
             expected_filename = 'C:/Users/Gorgoth/Downloads/JohnEveryman/' + file
             expected_url = 'https://www.vidble.com/' + file
-            self.assertEqual(expected_filename, content.filename)
+            self.assertEqual(expected_filename, content.make_filename())
 
     def check_output(self, content):
         self.assertEqual('https://vidble.com/XOwqxH6Xz9.jpg', content.url)
         self.assertEqual('Picture(s)', content.post_title)
         self.assertEqual('Pics', content.subreddit)
         self.assertEqual(1521473630, content.date_created)
-        self.assertEqual('C:/Users/Gorgoth/Downloads/JohnEveryman/XOwqxH6Xz9.jpg', content.filename)
+        self.assertEqual('C:/Users/Gorgoth/Downloads/JohnEveryman/XOwqxH6Xz9.jpg', content.make_filename())
 
     def get_single_soup(self):
         current_file_path = path.dirname(path.abspath(__file__))


### PR DESCRIPTION
Fixes files of all types from being overwritten when a file with the same name is downloaded.  The new files will now be fixed with an incrementing number to avoid duplicate names.

Also fixes the final part of issue #94 in which reddit video files with duplicate names were either overwriting the existing file or not merging.