### PR TITLE
Last downloaded fix

### DIFF
--- a/DownloaderForReddit/Core/Content.py
+++ b/DownloaderForReddit/Core/Content.py
@@ -83,13 +83,13 @@ class Content(QRunnable, QObject):
         if self.subreddit_save_method is None:
             path = self.save_path
         elif self.subreddit_save_method == 'User Name':
-            path = os.path.join(self.save_path, self.user)
+            path = SystemUtil.join_path(self.save_path, self.user)
         elif self.subreddit_save_method == 'Subreddit Name':
-            path = os.path.join(self.save_path, self.subreddit)
+            path = SystemUtil.join_path(self.save_path, self.subreddit)
         elif self.subreddit_save_method == 'Subreddit Name/User Name':
-            path = os.path.join(self.save_path, self.subreddit, self.user)
+            path = SystemUtil.join_path(self.save_path, self.subreddit, self.user)
         elif self.subreddit_save_method == 'User Name/Subreddit Name':
-            path = os.path.join(self.save_path, self.user, self.subreddit)
+            path = SystemUtil.join_path(self.save_path, self.user, self.subreddit)
         else:
             path = self.save_path
         return path

--- a/DownloaderForReddit/Core/Content.py
+++ b/DownloaderForReddit/Core/Content.py
@@ -25,14 +25,18 @@ along with Downloader for Reddit.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
 import requests
-from PyQt5.QtCore import QRunnable
+from PyQt5.QtCore import QRunnable, QObject, pyqtSignal
 import logging
 
 from ..Core import Const
 from ..Utils import Injector, SystemUtil, VideoMerger
 
 
-class Content(QRunnable):
+class DownloadSignal(QObject):
+    complete = pyqtSignal(dict)
+
+
+class Content(QRunnable, QObject):
 
     def __init__(self, url, user, post_title, subreddit, submission_id, number_in_seq, file_ext, save_path,
                  subreddit_save_method, date_created, display_only):
@@ -49,6 +53,7 @@ class Content(QRunnable):
         :param file_ext:  The extension of the file, used to save the file with the correct extension
         """
         super().__init__()
+        self.download_complete_signal = DownloadSignal()
         self.logger = logging.getLogger('DownloaderForReddit.%s' % __name__)
         self.settings_manager = Injector.get_settings_manager()
         self.url = url
@@ -61,6 +66,8 @@ class Content(QRunnable):
         self.file_ext = file_ext
         self.save_path = save_path.strip('/')
         self.subreddit_save_method = subreddit_save_method
+        # str name of the application stored reddit object for which this content item was created
+        self.significant_reddit_object = self.user if self.subreddit_save_method is None else self.subreddit
         self.date_created = date_created
         self.display_only = display_only
         self.output = ''
@@ -127,6 +134,8 @@ class Content(QRunnable):
             if self.settings_manager.set_file_modified_date:
                 SystemUtil.set_file_modify_time(self.filename, self.date_created)
             self.check_video_merger()
+            self.download_complete_signal.complete.emit({'reddit_object': self.significant_reddit_object,
+                                                                  'filename': self.filename})
             self.queue.put('Saved: %s' % self.filename)
             self.downloaded = True
         else:

--- a/DownloaderForReddit/Extractors/BaseExtractor.py
+++ b/DownloaderForReddit/Extractors/BaseExtractor.py
@@ -55,7 +55,7 @@ class BaseExtractor:
         self.settings_manager = Injector.get_settings_manager()
         self.url = post.url
         self.domain = post.domain
-        self.user = post.author
+        self.user = reddit_object if reddit_object.object_type == 'USER' else post.author
         self.post_title = post.title
         self.subreddit = post.subreddit if not reddit_object.object_type == 'SUBREDDIT' else reddit_object.name
         self.creation_date = post.created
@@ -190,8 +190,8 @@ class BaseExtractor:
         :rtype: Content
         """
         count = ' %s' % count if count else ''
-        x = Content(url, self.user, self.post_title, self.subreddit, file_name, count, '.' + extension, self.save_path,
-                    self.subreddit_save_method, self.creation_date, self.content_display_only)
+        x = Content(url, self.user_name, self.post_title, self.subreddit, file_name, count, '.' + extension,
+                    self.save_path, self.subreddit_save_method, self.creation_date, self.content_display_only)
         self.extracted_content.append(x)
         return x
 

--- a/DownloaderForReddit/Extractors/BaseExtractor.py
+++ b/DownloaderForReddit/Extractors/BaseExtractor.py
@@ -27,8 +27,8 @@ import requests
 import logging
 
 from ..Core.Content import Content
-from ..Utils import Injector
 from ..Core.Post import Post
+from ..Utils import Injector
 
 
 class BaseExtractor:

--- a/DownloaderForReddit/Utils/Injector.py
+++ b/DownloaderForReddit/Utils/Injector.py
@@ -23,8 +23,6 @@ along with Downloader for Reddit.  If not, see <http://www.gnu.org/licenses/>.
 """
 from queue import Queue
 
-from ..Persistence.SettingsManager import SettingsManager
-
 
 settings_manager = None
 queue = None
@@ -33,6 +31,7 @@ queue = None
 def get_settings_manager():
     global settings_manager
     if settings_manager is None:
+        from ..Persistence.SettingsManager import SettingsManager
         settings_manager = SettingsManager()
     return settings_manager
 

--- a/DownloaderForReddit/Utils/SystemUtil.py
+++ b/DownloaderForReddit/Utils/SystemUtil.py
@@ -156,3 +156,15 @@ def delete_file(file_path):
     """
     if os.path.exists(file_path):
         os.remove(file_path)
+
+
+def join_path(*args):
+    """
+    Used in place of os.path.join in order to give uniform path separators that display nicely to the user and work in
+    the system for designating file paths.  The default separator on windows is '\' which must be escaped, and does not
+    display well when joined.  However, Windows also accepts '/' as a file path separator, which is what allows this
+    method to work.
+    :param args:
+    :return:
+    """
+    return '/'.join(args)

--- a/Tests/UnitTests/Core/test_Content.py
+++ b/Tests/UnitTests/Core/test_Content.py
@@ -23,42 +23,47 @@ class TestContent(unittest.TestCase):
 
     def test_file_name_subreddit_save_method_none(self):
         self.make_content(None)
-        self.assertEqual(self.content.filename, '%s%s%s%s' % (self.save_path,
-                                                               self.content.clean_filename(self.submission_id),
-                                                               self.number_in_seq, self.file_ext))
+        filename = self.content.make_filename()
+        self.assertEqual(filename, '%s%s%s%s' % (self.save_path, self.content.clean_filename(self.submission_id),
+                                                 self.number_in_seq, self.file_ext))
 
     def test_file_name_subreddit_save_method_user_name(self):
         self.make_content('User Name')
+        filename = self.content.make_filename()
         correct_file_name = '%s%s/%s%s%s' % (self.save_path, self.user, self.content.clean_filename(self.submission_id),
                                              self.number_in_seq, self.file_ext)
-        self.assertEqual(self.content.filename, correct_file_name)
+        self.assertEqual(filename, correct_file_name)
 
     def test_file_name_subreddit_save_method_subreddit_name(self):
         self.make_content('Subreddit Name')
+        filename = self.content.make_filename()
         correct_file_name = '%s%s/%s%s%s' % (self.save_path, self.subreddit,
                                              self.content.clean_filename(self.submission_id), self.number_in_seq,
                                              self.file_ext)
-        self.assertEqual(self.content.filename, correct_file_name)
+        self.assertEqual(filename, correct_file_name)
 
     def test_file_name_subreddit_save_method_subreddit_name_user_name(self):
         self.make_content('Subreddit Name/User Name')
+        filename = self.content.make_filename()
         correct_file_name = '%s%s/%s/%s%s%s' % (self.save_path, self.subreddit, self.user,
                                                 self.content.clean_filename(self.submission_id), self.number_in_seq,
                                                 self.file_ext)
-        self.assertEqual(self.content.filename, correct_file_name)
+        self.assertEqual(filename, correct_file_name)
 
     def test_file_name_subreddit_save_method_user_name_subreddit_name(self):
         self.make_content('User Name/Subreddit Name')
+        filename = self.content.make_filename()
         correct_file_name = '%s%s/%s/%s%s%s' % (self.save_path, self.user, self.subreddit,
                                                 self.content.clean_filename(self.submission_id), self.number_in_seq,
                                                 self.file_ext)
-        self.assertEqual(self.content.filename, correct_file_name)
+        self.assertEqual(filename, correct_file_name)
 
     def test_file_name_default(self):
         self.make_content('Something Else')
+        filename = self.content.make_filename()
         correct_file_name = '%s%s%s%s' % (self.save_path, self.content.clean_filename(self.submission_id),
                                           self.number_in_seq, self.file_ext)
-        self.assertEqual(self.content.filename, correct_file_name)
+        self.assertEqual(filename, correct_file_name)
 
     def test_clean_file_name(self):
         name_one = 'this is a test of a name that has more than two hundred and thirty characters to see if the clean '\


### PR DESCRIPTION
The new content naming scheme, which was implemented to rename files with duplicate names instead of overwriting them, created a problem when trying to open the last download dialog in which the application would crash.  This PR fixes this issue.