### PR TITLE
Added fallback to redgifs

### DIFF
--- a/DownloaderForReddit/Extractors/GfycatExtractor.py
+++ b/DownloaderForReddit/Extractors/GfycatExtractor.py
@@ -27,6 +27,10 @@ from ..Extractors.BaseExtractor import BaseExtractor
 from ..Core import Const
 
 from urllib.parse import urlparse
+import requests
+
+_REDGIFS_ENDPOINT = "https://api.redgifs.com/v1/gfycats"
+_GFYCAT_ENDPOINT = "https://api.gfycat.com/v1/gfycats"
 
 class GfycatExtractor(BaseExtractor):
 
@@ -38,11 +42,7 @@ class GfycatExtractor(BaseExtractor):
         api
         """
         super().__init__(post, reddit_object, content_display_only)
-        item = urlparse(self.url)
-        if  item.hostname == 'redgifs.com':
-            self.api_caller = "https://api.redgifs.com/v1/gfycats/"
-        else:
-            self.api_caller = "https://api.gfycat.com/v1/gfycats/"
+
 
     def extract_content(self):
         """Dictates which extraction method should be used"""
@@ -56,9 +56,19 @@ class GfycatExtractor(BaseExtractor):
             self.handle_failed_extract(message=message, extractor_error_message=message)
 
     def extract_single(self):
-        domain, gif_id = self.url.rsplit('/', 1)
-        gif_id = gif_id.split('-',1)[0]
-        gfy_json = self.get_json(self.api_caller + gif_id)
+        item = urlparse(self.url)
+        gif_id = item.path.split('-', 1)[0]
+        print(gif_id)
+
+        if item.hostname == 'redgifs.com':
+            gfy_json = self.get_json(_REDGIFS_ENDPOINT + gif_id)
+        else:
+            response = requests.get(_GFYCAT_ENDPOINT + gif_id)
+            if response.status_code == 200 and 'json' in response.headers['Content-Type']:
+                gfy_json = response.json()
+            else:
+                gfy_json = self.get_json(_REDGIFS_ENDPOINT + gif_id)
+
         gfy_url = gfy_json.get('gfyItem').get('webmUrl')
-        file_name = self.get_filename(gif_id)
+        file_name = self.get_filename(gif_id[1:])
         self.make_content(gfy_url, file_name, 'webm')

--- a/DownloaderForReddit/Extractors/GfycatExtractor.py
+++ b/DownloaderForReddit/Extractors/GfycatExtractor.py
@@ -23,6 +23,7 @@ along with Downloader for Reddit.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 
+from os import path
 from urllib.parse import urlparse
 
 import requests
@@ -30,8 +31,8 @@ import requests
 from ..Core import Const
 from ..Extractors.BaseExtractor import BaseExtractor
 
-_REDGIFS_ENDPOINT = "https://api.redgifs.com/v1/gfycats"
-_GFYCAT_ENDPOINT = "https://api.gfycat.com/v1/gfycats"
+_REDGIFS_ENDPOINT = "https://api.redgifs.com/v1/gfycats/"
+_GFYCAT_ENDPOINT = "https://api.gfycat.com/v1/gfycats/"
 
 class GfycatExtractor(BaseExtractor):
 
@@ -57,7 +58,8 @@ class GfycatExtractor(BaseExtractor):
 
     def extract_single(self):
         item = urlparse(self.url)
-        gif_id = item.path.split('-', 1)[0]
+        gif_id = item.path
+        gif_id = path.basename(gif_id).split('-')[0]
         print(gif_id)
 
         if item.hostname == 'redgifs.com':

--- a/DownloaderForReddit/Extractors/GfycatExtractor.py
+++ b/DownloaderForReddit/Extractors/GfycatExtractor.py
@@ -23,18 +23,19 @@ along with Downloader for Reddit.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 
-from ..Extractors.BaseExtractor import BaseExtractor
-from ..Core import Const
-
 from urllib.parse import urlparse
+
 import requests
+
+from ..Core import Const
+from ..Extractors.BaseExtractor import BaseExtractor
 
 _REDGIFS_ENDPOINT = "https://api.redgifs.com/v1/gfycats"
 _GFYCAT_ENDPOINT = "https://api.gfycat.com/v1/gfycats"
 
 class GfycatExtractor(BaseExtractor):
 
-    url_key = ['gfycat','redgifs']
+    url_key = ['gfycat', 'redgifs']
 
     def __init__(self, post, reddit_object, content_display_only=False):
         """
@@ -42,7 +43,6 @@ class GfycatExtractor(BaseExtractor):
         api
         """
         super().__init__(post, reddit_object, content_display_only)
-
 
     def extract_content(self):
         """Dictates which extraction method should be used"""

--- a/DownloaderForReddit/Extractors/GfycatExtractor.py
+++ b/DownloaderForReddit/Extractors/GfycatExtractor.py
@@ -72,5 +72,5 @@ class GfycatExtractor(BaseExtractor):
                 gfy_json = self.get_json(_REDGIFS_ENDPOINT + gif_id)
 
         gfy_url = gfy_json.get('gfyItem').get('webmUrl')
-        file_name = self.get_filename(gif_id[1:])
+        file_name = self.get_filename(gif_id)
         self.make_content(gfy_url, file_name, 'webm')

--- a/Tests/UnitTests/Extractors/test_GfycatExtractor.py
+++ b/Tests/UnitTests/Extractors/test_GfycatExtractor.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
 from DownloaderForReddit.Extractors.GfycatExtractor import GfycatExtractor
 from DownloaderForReddit.Utils import Injector
@@ -12,19 +12,31 @@ class TestGfycatExtractor(unittest.TestCase):
     def setUp(self):
         Injector.settings_manager = MockSettingsManager()
 
-    @patch('DownloaderForReddit.Extractors.GfycatExtractor.get_json')
+    @patch('requests.get')
     def test_extract_single_untagged(self, j_mock):
         dir_url = 'https://giant.gfycat.com/KindlyElderlyCony.webm'
-        j_mock.return_value = {'gfyItem': {'webmUrl': dir_url}}
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.headers = {'Content-Type': 'json'}
+        mock_response.json.return_value = {'gfyItem': {'webmUrl': dir_url}}
+        j_mock.return_value = mock_response
+
         ge = GfycatExtractor(MockObjects.get_mock_post_gfycat(), MockObjects.get_blank_user())
         ge.extract_single()
         j_mock.assert_called_with('https://api.gfycat.com/v1/gfycats/KindlyElderlyCony')
         self.check_output(ge, dir_url)
 
-    @patch('DownloaderForReddit.Extractors.GfycatExtractor.get_json')
+    @patch('requests.get')
     def test_extract_single_tagged(self, j_mock):
         dir_url = 'https://giant.gfycat.com/anchoredenchantedamericanriverotter.webm'
-        j_mock.return_value = {'gfyItem': {'webmUrl': dir_url}}
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.headers = {'Content-Type': 'json'}
+        mock_response.json.return_value = {'gfyItem': {'webmUrl': dir_url}}
+        j_mock.return_value = mock_response
+
         ge = GfycatExtractor(MockObjects.get_mock_post_gfycat_tagged(), MockObjects.get_blank_user())
         ge.extract_single()
         j_mock.assert_called_with('https://api.gfycat.com/v1/gfycats/anchoredenchantedamericanriverotter')


### PR DESCRIPTION
Due to the GfyCat/Redgifs split, some gfycat links are now being serviced by redgifs instead. 

To account for this, the GfycatExtractor now queries the redgifs API before failing a gfycat link. 