### PR TITLE
fix: add a timeout to abort hanging requests

### DIFF
--- a/DownloaderForReddit/Core/Content.py
+++ b/DownloaderForReddit/Core/Content.py
@@ -105,7 +105,7 @@ class Content(QRunnable, QObject):
     def run(self):
         self.check_save_path_subreddit()
         try:
-            response = requests.get(self.url, stream=True)
+            response = requests.get(self.url, stream=True, timeout=10)
             if response.status_code == 200:
                 # defer filename creation to last possible second so any duplicate file names should have already been
                 # written and can thus be avoided

--- a/DownloaderForReddit/Core/UpdaterChecker.py
+++ b/DownloaderForReddit/Core/UpdaterChecker.py
@@ -62,7 +62,7 @@ class UpdateChecker(QObject):
             self.finished.emit()
 
     def retrieve_json_data(self):
-        response = requests.get(self.release_api_caller)
+        response = requests.get(self.release_api_caller, timeout=10)
         if response.status_code == 200:
             self._json = response.json()
         else:

--- a/DownloaderForReddit/Extractors/BaseExtractor.py
+++ b/DownloaderForReddit/Extractors/BaseExtractor.py
@@ -147,7 +147,7 @@ class BaseExtractor:
 
     def get_json(self, url):
         """Makes sure that a request is valid and handles without errors if the connection is not successful"""
-        response = requests.get(url)
+        response = requests.get(url, timeout=10)
         if response.status_code == 200 and 'json' in response.headers['Content-Type']:
             return response.json()
         else:
@@ -156,7 +156,7 @@ class BaseExtractor:
 
     def get_text(self, url):
         """See get_json"""
-        response = requests.get(url)
+        response = requests.get(url, timeout=10)
         if response.status_code == 200 and 'text' in response.headers['Content-Type']:
             return response.text
         else:

--- a/DownloaderForReddit/Extractors/GfycatExtractor.py
+++ b/DownloaderForReddit/Extractors/GfycatExtractor.py
@@ -65,7 +65,7 @@ class GfycatExtractor(BaseExtractor):
         if item.hostname == 'redgifs.com':
             gfy_json = self.get_json(_REDGIFS_ENDPOINT + gif_id)
         else:
-            response = requests.get(_GFYCAT_ENDPOINT + gif_id)
+            response = requests.get(_GFYCAT_ENDPOINT + gif_id, timeout=10)
             if response.status_code == 200 and 'json' in response.headers['Content-Type']:
                 gfy_json = response.json()
             else:

--- a/DownloaderForReddit/Utils/ImgurUtils.py
+++ b/DownloaderForReddit/Utils/ImgurUtils.py
@@ -61,7 +61,7 @@ def _send_request(url_extension, retries=1):
         headers['X-Mashape-Key'] = Injector.settings_manager.imgur_mashape_key
     else:
         raise ImgurError(429)
-    response = requests.get(url, headers=headers)
+    response = requests.get(url, headers=headers, timeout=10)
     if response.status_code == 200:
         return response.json()
     if response.status_code == 429:
@@ -77,7 +77,7 @@ def check_credits():
     headers = {
         'Authorization': 'Client-ID {}'.format(Injector.settings_manager.imgur_client_id)
     }
-    response = requests.get(url, headers=headers)
+    response = requests.get(url, headers=headers, timeout=10)
     if response.status_code != 200:
         raise ImgurError(response.status_code)
     result = response.json()

--- a/Tests/UnitTests/Extractors/test_GfycatExtractor.py
+++ b/Tests/UnitTests/Extractors/test_GfycatExtractor.py
@@ -24,7 +24,7 @@ class TestGfycatExtractor(unittest.TestCase):
 
         ge = GfycatExtractor(MockObjects.get_mock_post_gfycat(), MockObjects.get_blank_user())
         ge.extract_single()
-        j_mock.assert_called_with('https://api.gfycat.com/v1/gfycats/KindlyElderlyCony')
+        j_mock.assert_called_with('https://api.gfycat.com/v1/gfycats/KindlyElderlyCony', timeout=10)
         self.check_output(ge, dir_url)
 
     @patch('requests.get')
@@ -39,7 +39,7 @@ class TestGfycatExtractor(unittest.TestCase):
 
         ge = GfycatExtractor(MockObjects.get_mock_post_gfycat_tagged(), MockObjects.get_blank_user())
         ge.extract_single()
-        j_mock.assert_called_with('https://api.gfycat.com/v1/gfycats/anchoredenchantedamericanriverotter')
+        j_mock.assert_called_with('https://api.gfycat.com/v1/gfycats/anchoredenchantedamericanriverotter', timeout=10)
         self.check_output_tagged(ge, dir_url)
 
     def test_direct_extraction(self):

--- a/Tests/UnitTests/Utils/test_ImgurUtils.py
+++ b/Tests/UnitTests/Utils/test_ImgurUtils.py
@@ -27,7 +27,7 @@ class TestImgurUtils(unittest.TestCase):
         header = {
             'Authorization': 'Client-ID {{CLIENT ID}}'
         }
-        req_mock.assert_called_with(url, headers=header)
+        req_mock.assert_called_with(url, headers=header, timeout=10)
         self.assertEqual(497, value)
         self.assertEqual(497, ImgurUtils.num_credits)
         self.assertEqual(1584168402, ImgurUtils.credit_reset_time)


### PR DESCRIPTION
For many reasons, http requests may hang. I'll just defer to the official docs:

> Nearly all production code should use this parameter in nearly all requests. Failure to do so can cause your program to hang indefinitely

https://2.python-requests.org/en/master/user/quickstart/#timeouts

I was finding that DownloaderForReddit would sometimes hang forever. Adding this timeout fixed it and downloads were correctly recognized as failed.