### PR TITLE
Fixed release not being made when multiple commits pushed

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -20,13 +20,16 @@ jobs:
 
     steps:
 
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Check Version
-        uses: tj-actions/changed-files@v12
+        uses: tj-actions/changed-files@v14.3
         id: check-version
         with:
           files: DownloaderForReddit/version.py
+          since_last_remote_commit: "true"
 
       - name: Read Changelog
         id: changes


### PR DESCRIPTION
The Version 3.14 release failed to create because 3fe8ee3d2c11e8b9d54fe643549d52ac365f51e2 was pushed with 420f38eb06a77e395a8bb3a552874d30ea72823b. This PR fixes the workflow so that this doesn't happen in the future. 

Note: The release for 3.14 will have to be manually triggered. The easiest way is as follows: 

1. Create a branch called `release_test` at commit 3fe8ee3d2c11e8b9d54fe643549d52ac365f51e2.
2. Push the branch to the repo. 
3. Once the release has been created, you can delete the `release_test` branch. 