### PR TITLE
Fix content and posts with no errors not being retried

### DIFF
--- a/DownloaderForReddit/core/download_runner.py
+++ b/DownloaderForReddit/core/download_runner.py
@@ -7,6 +7,7 @@ import prawcore
 from PyQt5.QtCore import QObject, pyqtSignal
 from collections import namedtuple
 from praw.models import Redditor
+from sqlalchemy import or_
 
 from .downloader import Downloader
 from .content_runner import ContentRunner
@@ -148,7 +149,7 @@ class DownloadRunner(QObject):
                 post_id_list = session.query(Post.id)\
                     .filter(Post.extracted == False) \
                     .filter(Post.retry_attempts <= 3) \
-                    .filter(Post.extraction_error.notin_(NON_DOWNLOADABLE))
+                    .filter(or_(Post.extraction_error == None, Post.extraction_error.notin_(NON_DOWNLOADABLE)))
         self.logger.debug(f'{post_id_list.count()} unfinished posts to download')
         for post_id, in post_id_list.all():  # comma used to unpack result tuple
             extraction_set = ExtractionSet(extraction_type='POST', extraction_object=post_id, significant_id=None)
@@ -163,7 +164,7 @@ class DownloadRunner(QObject):
                 content_id_list = session.query(Content)\
                     .filter(Content.downloaded == False) \
                     .filter(Content.retry_attempts <= 3) \
-                    .filter(Content.download_error.notin_(NON_DOWNLOADABLE))
+                    .filter(or_(Content.download_error == None, Content.download_error.notin_(NON_DOWNLOADABLE)))
         self.logger.debug(f'{content_id_list.count()} unfinished content items to download')
         for content in content_id_list.all():
             self.download_queue.put(content.id)


### PR DESCRIPTION
Fix a database query error that prevented posts and content without an error from being pulled from the database when attempting to re-run failed downloads/extractions.