### PR TITLE
Fix multi-part downloader

### DIFF
--- a/DownloaderForReddit/core/download/__init__.py
+++ b/DownloaderForReddit/core/download/__init__.py
@@ -1,0 +1,3 @@
+# A dict comprised of they key value being a content's id, and the value being a dict of header information that needs
+# to be sent with the download request in order to get a successful response.
+HEADERS = {}

--- a/DownloaderForReddit/core/download/downloader.py
+++ b/DownloaderForReddit/core/download/downloader.py
@@ -2,25 +2,20 @@ import requests
 import logging
 from concurrent.futures import ThreadPoolExecutor
 
-from .runner import Runner, verify_run
+from DownloaderForReddit.core.runner import Runner, verify_run
 from .multipart_downloader import MultipartDownloader
-from .errors import Error
-from ..utils import injector, system_util, general_utils
-from ..database import Content
-from ..messaging.message import Message
+from . import HEADERS
+from DownloaderForReddit.core.errors import Error
+from DownloaderForReddit.utils import injector, system_util, general_utils
+from DownloaderForReddit.database import Content
+from DownloaderForReddit.messaging.message import Message
 
 
 class Downloader(Runner):
 
     """
     The class that is responsible for the actual downloading of content.
-
-    Attributes:
-        HEADERS: A dict comprised of they key value being a content's id, and the value being a dict of header
-            information that needs to be sent with the download request in order to get a successful response.
     """
-
-    HEADERS = {}
 
     def __init__(self, download_queue, download_session_id, stop_run):
         """
@@ -69,7 +64,7 @@ class Downloader(Runner):
             else:
                 break
         self.executor.shutdown(wait=True)
-        Downloader.HEADERS.clear()
+        HEADERS.clear()
         self.logger.debug('Downloader exiting')
 
     def remove_future(self, future):
@@ -92,7 +87,7 @@ class Downloader(Runner):
                     if self.settings_manager.use_multi_part_downloader and \
                             file_size > self.settings_manager.multi_part_threshold:
                         multi_part_downloader = MultipartDownloader(self.stop_run)
-                        multi_part_downloader.run(content.url, file_path, file_size)
+                        multi_part_downloader.run(content, file_path, file_size)
                         self.finish_multi_part_download(content, multi_part_downloader)
                     else:
                         with open(file_path, 'wb') as file:
@@ -121,7 +116,7 @@ class Downloader(Runner):
         """
         if 'erome' in content.url:
             return {"Referer": "https://www.erome.com/"}
-        return Downloader.HEADERS.get(content.id, None)
+        return HEADERS.get(content.id, None)
 
     def finish_download(self, content: Content):
         """

--- a/DownloaderForReddit/core/download_runner.py
+++ b/DownloaderForReddit/core/download_runner.py
@@ -9,7 +9,7 @@ from collections import namedtuple
 from praw.models import Redditor
 from sqlalchemy import or_
 
-from .downloader import Downloader
+from DownloaderForReddit.core.download.downloader import Downloader
 from .content_runner import ContentRunner
 from .submission_filter import SubmissionFilter
 from .runner import verify_run

--- a/DownloaderForReddit/core/update_runner.py
+++ b/DownloaderForReddit/core/update_runner.py
@@ -5,7 +5,7 @@ from threading import Thread, Event
 from PyQt5.QtCore import QObject, pyqtSignal
 
 from .submission_handler import SubmissionHandler
-from .downloader import Downloader
+from DownloaderForReddit.core.download.downloader import Downloader
 from .runner import verify_run
 from ..database.models import DownloadSession, Post
 from ..utils import injector, reddit_utils

--- a/DownloaderForReddit/extractors/redgifs_extractor.py
+++ b/DownloaderForReddit/extractors/redgifs_extractor.py
@@ -1,8 +1,8 @@
 from yt_dlp import YoutubeDL
 
 from .base_extractor import BaseExtractor
-from ..core.downloader import Downloader
 from ..core.errors import Error
+from ..core.download import HEADERS
 
 
 class RedgifsExtractor(BaseExtractor):
@@ -51,7 +51,7 @@ class RedgifsExtractor(BaseExtractor):
             with YoutubeDL({'format': 'mp4'}) as ydl:
                 result = ydl.extract_info(self.url, download=False)
                 content = self.make_content(result['url'], 'mp4')
-                Downloader.HEADERS[content.id] = result['http_headers']
+                HEADERS[content.id] = result['http_headers']
         except:
             message = 'Failed to locate content'
             self.handle_failed_extract(error=Error.FAILED_TO_LOCATE, message=message, extractor_error_message=message)


### PR DESCRIPTION
The multi-part downloader was not performing correctly with the addition of making download requests with required headers.  This fix makes the multi-part downloader pull from the same header library that the main downloader now uses.