### PR TITLE
Fix redgifs extractor reporting false errors for duplicate content

### DIFF
--- a/DownloaderForReddit/extractors/redgifs_extractor.py
+++ b/DownloaderForReddit/extractors/redgifs_extractor.py
@@ -53,7 +53,8 @@ class RedgifsExtractor(BaseExtractor):
             response = api.get_gif(self.get_gif_id())
             url = self.get_download_url(response)
             content = self.make_content(url, 'mp4')
-            HEADERS[content.id] = api.http.headers
+            if content is not None:
+                HEADERS[content.id] = api.http.headers
         except:
             message = 'Failed to extract content from redgifs'
             self.handle_failed_extract(error=Error.FAILED_TO_LOCATE, message=message, exetractor_error_message=message)


### PR DESCRIPTION
Fix #322

Duplicate redgifs content was being falsely reported as a failed extract.