### PR TITLE
Fix download scheduler not storing multiple download tasks

### DIFF
--- a/DownloaderForReddit/scheduling/scheduler.py
+++ b/DownloaderForReddit/scheduling/scheduler.py
@@ -71,8 +71,8 @@ class Scheduler(QObject):
 
     def schedule_task(self, task):
         """
-        Attempts to schedule the task with he scheduling module.
-        :param task: A task model instance that will scheduled with the scheduling module.
+        Attempts to schedule the task with the scheduling module.
+        :param task: A task model instance that will schedule with the scheduling module.
         :type task DownloadTask
         """
         try:

--- a/DownloaderForReddit/scheduling/tasks.py
+++ b/DownloaderForReddit/scheduling/tasks.py
@@ -32,6 +32,10 @@ class Interval(Enum):
         return self.name.lower()
 
 
+def generate_uuid():
+    return uuid4().hex
+
+
 class DownloadTask(Base):
 
     __tablename__ = 'download_task'
@@ -44,7 +48,7 @@ class DownloadTask(Base):
     subreddit_list_id = Column(ForeignKey('reddit_object_list.id'), nullable=True)
     subreddit_list = relationship(RedditObjectList, backref='scheduled_subreddit_downloads',
                                   foreign_keys=[subreddit_list_id])
-    tag = Column(String, default=uuid4().hex, unique=True)
+    tag = Column(String, default=generate_uuid, unique=True)
     active = Column(Boolean, default=True)
 
     @property


### PR DESCRIPTION
Fix #323 

Scheduled download tasks stored in the database were using the same UUID number instead of generating new ones.  This was causing a crash when trying to add more than one task because of the unique constraint on that database column.