### PR TITLE
Improved rate limit handling

### DIFF
--- a/DownloaderForReddit/core/const.py
+++ b/DownloaderForReddit/core/const.py
@@ -37,3 +37,4 @@ FIRST_POST_EPOCH = 1119537833
 RESOURCES = os.path.abspath('Resources/')
 SUPPORTED_SITES_FILE = os.path.join(RESOURCES, 'supported_video_sites.txt')
 TIMEOUT_INCREMENT = 0.25
+RATE_LIMIT_DOC_URL = 'https://github.com/MalloyDelacroix/DownloaderForReddit/wiki/The-Ongoing-Impact-of-Reddits-API-Rate-Limits'

--- a/DownloaderForReddit/customwidgets/link_cursor_handler.py
+++ b/DownloaderForReddit/customwidgets/link_cursor_handler.py
@@ -1,0 +1,50 @@
+from PyQt5.QtCore import QEvent, Qt, QObject
+from PyQt5.QtGui import QTextDocument
+
+
+class LinkCursorHandler(QObject):
+    """
+    Handles mouse cursor changes when hovering over items that contain links in a
+    list view.
+
+    This class monitors mouse movements and dynamically changes the cursor to
+    indicate actionable links within items in a list view. This is achieved by
+    installing an event filter on the viewport of the list view. It detects mouse
+    hovering on HTML elements within the list view and updates the cursor
+    to a pointer when hovering over hyperlinks.  The cursor is otherwise
+    reset to a default cursor.
+
+    :ivar view: The associated list view widget whose mouse events are being tracked.
+    :type view: QListView
+    """
+    def __init__(self, list_view):
+        super().__init__()
+        self.view = list_view
+        self.view.setMouseTracking(True)
+        self.view.viewport().installEventFilter(self)
+
+    def eventFilter(self, obj, event):
+        if event.type() == QEvent.MouseMove:
+            index = self.view.indexAt(event.pos())
+            if not index.isValid():
+                self.view.setCursor(Qt.ArrowCursor)
+                return False
+
+            option = self.view.viewOptions()
+            option.rect = self.view.visualRect(index)
+
+            html = index.data(Qt.DisplayRole)
+            doc = QTextDocument()
+            doc.setHtml(html)
+            pos_in_item = event.pos() - option.rect.topLeft()
+
+            anchor = doc.documentLayout().anchorAt(pos_in_item)
+            if anchor:
+                self.view.setCursor(Qt.PointingHandCursor)
+            else:
+                self.view.setCursor(Qt.ArrowCursor)
+
+        elif event.type() == QEvent.Leave:
+            self.view.setCursor(Qt.ArrowCursor)
+
+        return False

--- a/DownloaderForReddit/gui/downloader_for_reddit_gui.py
+++ b/DownloaderForReddit/gui/downloader_for_reddit_gui.py
@@ -57,6 +57,7 @@ from ..database.model_manager import ModelManger
 from ..utils import (injector, system_util, imgur_utils, video_merger, general_utils, UpdateChecker, reddit_utils)
 from ..viewmodels.reddit_object_list_model import RedditObjectListModel
 from ..viewmodels.output_view_model import OutputViewModel
+from ..viewmodels.hyperlink_delegate import HyperlinkDelegate
 from ..messaging.message import MessageType, MessagePriority, Message
 from ..version import __version__
 
@@ -117,6 +118,7 @@ class DownloaderForRedditGUI(QMainWindow, Ui_MainWindow):
 
         self.output_view_model = OutputViewModel()
         self.output_list_view.setModel(self.output_view_model)
+        self.output_list_view.setItemDelegate(HyperlinkDelegate())
         self.output_view_model.added.connect(self.scroll_output)
 
         reddit_utils.load_token()

--- a/DownloaderForReddit/gui/downloader_for_reddit_gui.py
+++ b/DownloaderForReddit/gui/downloader_for_reddit_gui.py
@@ -59,6 +59,7 @@ from ..viewmodels.reddit_object_list_model import RedditObjectListModel
 from ..viewmodels.output_view_model import OutputViewModel
 from ..viewmodels.hyperlink_delegate import HyperlinkDelegate
 from ..messaging.message import MessageType, MessagePriority, Message
+from ..customwidgets.link_cursor_handler import LinkCursorHandler
 from ..version import __version__
 
 
@@ -119,6 +120,7 @@ class DownloaderForRedditGUI(QMainWindow, Ui_MainWindow):
         self.output_view_model = OutputViewModel()
         self.output_list_view.setModel(self.output_view_model)
         self.output_list_view.setItemDelegate(HyperlinkDelegate())
+        self.link_cursor_handler = LinkCursorHandler(self.output_list_view)
         self.output_view_model.added.connect(self.scroll_output)
 
         reddit_utils.load_token()

--- a/DownloaderForReddit/utils/html_formatting.py
+++ b/DownloaderForReddit/utils/html_formatting.py
@@ -1,0 +1,31 @@
+import re
+
+
+def format_html(html_text: str) -> str:
+    """
+    Formats a given HTML text by replacing newline characters with HTML line break
+    tags and wrapping the entire text with paragraph tags.
+
+    :param html_text: The HTML text to format.
+    :return: The formatted HTML text.
+    """
+    html_text = html_text.replace('\n', '<br/>')
+    html_text = linkify_urls(html_text)
+    return f'<p>{html_text}</p>'
+
+
+def linkify_urls(text: str) -> str:
+    """
+    Converts all URLs in a given string into clickable HTML anchor links.
+
+    :param text: The input string containing URLs that need to be converted
+        into clickable HTML links.
+    :return: A string where any valid URLs are replaced with equivalent clickable
+        anchor links in HTML format.
+    """
+    url_regex = re.compile(
+        r'(https?://[^\s"<>()]+)',  # match http(s) URLs excluding common HTML-breaking chars
+        re.IGNORECASE
+    )
+
+    return url_regex.sub(r'<a href="\1">\1</a>', text)

--- a/DownloaderForReddit/viewmodels/hyperlink_delegate.py
+++ b/DownloaderForReddit/viewmodels/hyperlink_delegate.py
@@ -1,0 +1,39 @@
+from PyQt5.QtWidgets import QStyledItemDelegate
+from PyQt5.QtGui import QTextDocument
+from PyQt5.QtCore import QEvent, Qt
+import webbrowser
+
+
+class HyperlinkDelegate(QStyledItemDelegate):
+    """
+    Provides a delegate for rendering hyperlinks in item views.
+
+    This class inherits from QStyledItemDelegate and is used to display and interact with
+    content containing hyperlinks within item views. It renders HTML content and handles
+    mouse events to support hyperlink navigation.
+    """
+    def paint(self, painter, option, index):
+        doc = QTextDocument()
+        doc.setHtml(index.data(Qt.DisplayRole))
+        doc.setTextWidth(option.rect.width())
+        painter.save()
+        painter.translate(option.rect.topLeft())
+        doc.drawContents(painter)
+        painter.restore()
+
+    def sizeHint(self, option, index):
+        doc = QTextDocument()
+        doc.setHtml(index.data(Qt.DisplayRole))
+        doc.setTextWidth(option.rect.width())
+        return doc.size().toSize()
+
+    def editorEvent(self, event, model, option, index):
+        if event.type() == QEvent.MouseButtonRelease and event.button() == Qt.LeftButton:
+            doc = QTextDocument()
+            doc.setHtml(index.data(Qt.DisplayRole))
+            pos = event.pos() - option.rect.topLeft()
+            anchor = doc.documentLayout().anchorAt(pos)
+            if anchor:
+                webbrowser.open(anchor)
+                return True
+        return False

--- a/DownloaderForReddit/viewmodels/hyperlink_delegate.py
+++ b/DownloaderForReddit/viewmodels/hyperlink_delegate.py
@@ -1,3 +1,4 @@
+import re
 from PyQt5.QtWidgets import QStyledItemDelegate, QStyleOptionViewItem
 from PyQt5.QtGui import QTextDocument, QTextCursor, QTextCharFormat
 from PyQt5.QtCore import QEvent, Qt, QModelIndex
@@ -95,4 +96,22 @@ class HyperlinkDelegate(QStyledItemDelegate):
         :return: The formatted HTML text.
         """
         html_text = html_text.replace('\n', '<br/>')
+        html_text = HyperlinkDelegate.linkify_urls(html_text)
         return f'<p>{html_text}</p>'
+
+    @staticmethod
+    def linkify_urls(text: str) -> str:
+        """
+        Converts all URLs in a given string into clickable HTML anchor links.
+
+        :param text: The input string containing URLs that need to be converted
+            into clickable HTML links.
+        :return: A string where any valid URLs are replaced with equivalent clickable
+            anchor links in HTML format.
+        """
+        url_regex = re.compile(
+            r'(https?://[^\s"<>()]+)',  # match http(s) URLs excluding common HTML-breaking chars
+            re.IGNORECASE
+        )
+
+        return url_regex.sub(r'<a href="\1">\1</a>', text)

--- a/DownloaderForReddit/viewmodels/hyperlink_delegate.py
+++ b/DownloaderForReddit/viewmodels/hyperlink_delegate.py
@@ -1,4 +1,3 @@
-import re
 from PyQt5.QtWidgets import QStyledItemDelegate, QStyleOptionViewItem
 from PyQt5.QtGui import QTextDocument, QTextCursor, QTextCharFormat
 from PyQt5.QtCore import QEvent, Qt, QModelIndex
@@ -58,8 +57,7 @@ class HyperlinkDelegate(QStyledItemDelegate):
         """
         doc = QTextDocument()
         html = index.data(Qt.DisplayRole)
-        formatted_html = self.format_html(html)
-        doc.setHtml(formatted_html)
+        doc.setHtml(html)
         color = index.data(Qt.ForegroundRole)
 
         if color:
@@ -78,40 +76,11 @@ class HyperlinkDelegate(QStyledItemDelegate):
         """
         if event.type() == QEvent.MouseButtonRelease and event.button() == Qt.LeftButton:
             doc = QTextDocument()
-            doc.setHtml(index.data(Qt.DisplayRole))
+            html = index.data(Qt.DisplayRole)
+            doc.setHtml(html)
             pos = event.pos() - option.rect.topLeft()
             anchor = doc.documentLayout().anchorAt(pos)
             if anchor:
                 webbrowser.open(anchor)
                 return True
         return False
-
-    @staticmethod
-    def format_html(html_text: str) -> str:
-        """
-        Formats a given HTML text by replacing newline characters with HTML line break
-        tags and wrapping the entire text with paragraph tags.
-
-        :param html_text: The HTML text to format.
-        :return: The formatted HTML text.
-        """
-        html_text = html_text.replace('\n', '<br/>')
-        html_text = HyperlinkDelegate.linkify_urls(html_text)
-        return f'<p>{html_text}</p>'
-
-    @staticmethod
-    def linkify_urls(text: str) -> str:
-        """
-        Converts all URLs in a given string into clickable HTML anchor links.
-
-        :param text: The input string containing URLs that need to be converted
-            into clickable HTML links.
-        :return: A string where any valid URLs are replaced with equivalent clickable
-            anchor links in HTML format.
-        """
-        url_regex = re.compile(
-            r'(https?://[^\s"<>()]+)',  # match http(s) URLs excluding common HTML-breaking chars
-            re.IGNORECASE
-        )
-
-        return url_regex.sub(r'<a href="\1">\1</a>', text)

--- a/DownloaderForReddit/viewmodels/hyperlink_delegate.py
+++ b/DownloaderForReddit/viewmodels/hyperlink_delegate.py
@@ -13,8 +13,18 @@ class HyperlinkDelegate(QStyledItemDelegate):
     mouse events to support hyperlink navigation.
     """
     def paint(self, painter, option, index):
+        """
+        Overrides the paint method to render hyperlinks and colored text in the item view.
+
+        :param painter: QPainter object used for rendering the text.
+        :param option: QStyleOptionViewItem containing options for rendering the item.
+        :param index: QModelIndex providing access to model data.
+        :return: None
+        """
         doc = QTextDocument()
-        doc.setHtml(index.data(Qt.DisplayRole))
+        html = index.data(Qt.DisplayRole)
+        formatted_html = self.format_html(html)
+        doc.setHtml(formatted_html)
         color = index.data(Qt.ForegroundRole)
 
         if color:
@@ -37,6 +47,9 @@ class HyperlinkDelegate(QStyledItemDelegate):
         return doc.size().toSize()
 
     def editorEvent(self, event, model, option, index):
+        """
+        Overrides the editorEvent method to handle mouse events for hyperlink navigation.
+        """
         if event.type() == QEvent.MouseButtonRelease and event.button() == Qt.LeftButton:
             doc = QTextDocument()
             doc.setHtml(index.data(Qt.DisplayRole))
@@ -46,3 +59,15 @@ class HyperlinkDelegate(QStyledItemDelegate):
                 webbrowser.open(anchor)
                 return True
         return False
+
+    @staticmethod
+    def format_html(html_text: str) -> str:
+        """
+        Formats a given HTML text by replacing newline characters with HTML line break
+        tags and wrapping the entire text with paragraph tags.
+
+        :param html_text: The HTML text to format.
+        :return: The formatted HTML text.
+        """
+        html_text = html_text.replace('\n', '<br/>')
+        return f'<p>{html_text}</p>'

--- a/DownloaderForReddit/viewmodels/hyperlink_delegate.py
+++ b/DownloaderForReddit/viewmodels/hyperlink_delegate.py
@@ -1,5 +1,5 @@
 from PyQt5.QtWidgets import QStyledItemDelegate
-from PyQt5.QtGui import QTextDocument
+from PyQt5.QtGui import QTextDocument, QTextCursor, QTextCharFormat
 from PyQt5.QtCore import QEvent, Qt
 import webbrowser
 
@@ -15,6 +15,15 @@ class HyperlinkDelegate(QStyledItemDelegate):
     def paint(self, painter, option, index):
         doc = QTextDocument()
         doc.setHtml(index.data(Qt.DisplayRole))
+        color = index.data(Qt.ForegroundRole)
+
+        if color:
+            cursor = QTextCursor(doc)
+            cursor.select(QTextCursor.Document)
+            fmt = QTextCharFormat()
+            fmt.setForeground(color)
+            cursor.mergeCharFormat(fmt)
+
         doc.setTextWidth(option.rect.width())
         painter.save()
         painter.translate(option.rect.topLeft())

--- a/DownloaderForReddit/viewmodels/hyperlink_delegate.py
+++ b/DownloaderForReddit/viewmodels/hyperlink_delegate.py
@@ -44,9 +44,7 @@ class HyperlinkDelegate(QStyledItemDelegate):
     def get_document(self, option: QStyleOptionViewItem, index: QModelIndex) -> QTextDocument:
         """
         Generates a QTextDocument object with formatted HTML content and foreground
-        color based on provided index data. The method applies formatting to the
-        HTML content before setting it to the document and adjusts the text width
-        according to the specified option.
+        color based on provided index data.
 
         :param option: The style option which provides information such as the rectangle
                        dimensions to adjust the document's text width.

--- a/DownloaderForReddit/viewmodels/output_view_model.py
+++ b/DownloaderForReddit/viewmodels/output_view_model.py
@@ -1,7 +1,7 @@
 from PyQt5.QtCore import QAbstractListModel, QModelIndex, Qt, QVariant, pyqtSignal
 from PyQt5.QtGui import QColor
 
-from ..utils import injector
+from ..utils import injector, html_formatting
 
 
 class OutputViewModel(QAbstractListModel):
@@ -57,9 +57,11 @@ class OutputViewModel(QAbstractListModel):
         row = index.row()
         if role == Qt.DisplayRole:
             if self.settings_manager.show_priority_level:
-                return self.display_messages[row].output
+                text = self.display_messages[row].output
             else:
-                return self.display_messages[row].message
+                text = self.display_messages[row].message
+            formatted_text = html_formatting.format_html(text)
+            return formatted_text
         if role == Qt.ForegroundRole and self.settings_manager.use_color_output:
             r, g, b = getattr(self.settings_manager, f'{self.display_messages[row].priority.name.lower()}_color')
             return QColor(r, g, b)

--- a/Tests/unittests/utils/test_html_formatting.py
+++ b/Tests/unittests/utils/test_html_formatting.py
@@ -1,66 +1,66 @@
 from unittest import TestCase
 
-from DownloaderForReddit.viewmodels.hyperlink_delegate import HyperlinkDelegate
+from DownloaderForReddit.utils.html_formatting import linkify_urls, format_html
 
 
-class TestHyperlinkDelegate(TestCase):
+class TestHtmlFormatting(TestCase):
 
     def test_linkify_urls_basic(self):
         input_text = 'Check out this sick link: https://example.com'
         expected_output = 'Check out this sick link: <a href="https://example.com">https://example.com</a>'
-        self.assertEqual(HyperlinkDelegate.linkify_urls(input_text), expected_output)
+        self.assertEqual(linkify_urls(input_text), expected_output)
 
     def test_linkify_urls_multiple_links(self):
         input_text = 'Visit https://example.com and http://test.com'
         expected_output = 'Visit <a href="https://example.com">https://example.com</a> and <a href="http://test.com">http://test.com</a>'
-        self.assertEqual(HyperlinkDelegate.linkify_urls(input_text), expected_output)
+        self.assertEqual(linkify_urls(input_text), expected_output)
 
     def test_linkify_urls_no_links(self):
         input_output_text = 'No URLs here, just plain text.'
         # Input and output should be the same with no URLs
-        self.assertEqual(HyperlinkDelegate.linkify_urls(input_output_text), input_output_text)
+        self.assertEqual(linkify_urls(input_output_text), input_output_text)
 
     def test_linkify_urls_empty_value_supplied(self):
         input_output_text = ''
         # Input and output should be the same when empty value is given
-        self.assertEqual(HyperlinkDelegate.linkify_urls(input_output_text), input_output_text)
+        self.assertEqual(linkify_urls(input_output_text), input_output_text)
 
     def test_linkify_urls_with_special_characters(self):
         input_text = 'Check https://example.com/path?query=param&key=value'
         expected_output = 'Check <a href="https://example.com/path?query=param&key=value">https://example.com/path?query=param&key=value</a>'
-        self.assertEqual(HyperlinkDelegate.linkify_urls(input_text), expected_output)
+        self.assertEqual(linkify_urls(input_text), expected_output)
 
     def test_linkify_urls_embedded_with_other_text(self):
         input_text = 'Link in text:before https://example.com after:text'
         expected_output = 'Link in text:before <a href="https://example.com">https://example.com</a> after:text'
-        self.assertEqual(HyperlinkDelegate.linkify_urls(input_text), expected_output)
+        self.assertEqual(linkify_urls(input_text), expected_output)
 
     def test_linkify_urls_with_complex_url(self):
         input_text = 'Very link, much wow: http://www.test.com/path/to/embeded/location/many/pathsegments/?query=param&key=value#fragment'
         expected_output = 'Very link, much wow: <a href="http://www.test.com/path/to/embeded/location/many/pathsegments/?query=param&key=value#fragment">http://www.test.com/path/to/embeded/location/many/pathsegments/?query=param&key=value#fragment</a>'
-        self.assertEqual(HyperlinkDelegate.linkify_urls(input_text), expected_output)
+        self.assertEqual(linkify_urls(input_text), expected_output)
 
     def test_format_html_single_line(self):
         input_text = 'This is a test'
         expected_output = '<p>This is a test</p>'
-        self.assertEqual(HyperlinkDelegate.format_html(input_text), expected_output)
+        self.assertEqual(format_html(input_text), expected_output)
 
     def test_format_html_multiple_lines(self):
         input_text = 'This is a test\nWith multiple lines\nFor formatting'
         expected_output = '<p>This is a test<br/>With multiple lines<br/>For formatting</p>'
-        self.assertEqual(HyperlinkDelegate.format_html(input_text), expected_output)
+        self.assertEqual(format_html(input_text), expected_output)
 
     def test_format_html_empty_string(self):
         input_text = ''
         expected_output = '<p></p>'
-        self.assertEqual(HyperlinkDelegate.format_html(input_text), expected_output)
+        self.assertEqual(format_html(input_text), expected_output)
 
     def test_format_html_newline_only(self):
         input_text = '\n\n'
         expected_output = '<p><br/><br/></p>'
-        self.assertEqual(HyperlinkDelegate.format_html(input_text), expected_output)
+        self.assertEqual(format_html(input_text), expected_output)
 
     def test_format_html_with_a_link_in_text(self):
         input_text = 'This is a test\nWith multiple lines\nFor formatting\nhttps://example.com'
         expected_output = '<p>This is a test<br/>With multiple lines<br/>For formatting<br/><a href="https://example.com">https://example.com</a></p>'
-        self.assertEqual(HyperlinkDelegate.format_html(input_text), expected_output)
+        self.assertEqual(format_html(input_text), expected_output)

--- a/Tests/unittests/viewmodels/test_hyperlink_delegate.py
+++ b/Tests/unittests/viewmodels/test_hyperlink_delegate.py
@@ -1,0 +1,66 @@
+from unittest import TestCase
+
+from DownloaderForReddit.viewmodels.hyperlink_delegate import HyperlinkDelegate
+
+
+class TestHyperlinkDelegate(TestCase):
+
+    def test_linkify_urls_basic(self):
+        input_text = 'Check out this sick link: https://example.com'
+        expected_output = 'Check out this sick link: <a href="https://example.com">https://example.com</a>'
+        self.assertEqual(HyperlinkDelegate.linkify_urls(input_text), expected_output)
+
+    def test_linkify_urls_multiple_links(self):
+        input_text = 'Visit https://example.com and http://test.com'
+        expected_output = 'Visit <a href="https://example.com">https://example.com</a> and <a href="http://test.com">http://test.com</a>'
+        self.assertEqual(HyperlinkDelegate.linkify_urls(input_text), expected_output)
+
+    def test_linkify_urls_no_links(self):
+        input_output_text = 'No URLs here, just plain text.'
+        # Input and output should be the same with no URLs
+        self.assertEqual(HyperlinkDelegate.linkify_urls(input_output_text), input_output_text)
+
+    def test_linkify_urls_empty_value_supplied(self):
+        input_output_text = ''
+        # Input and output should be the same when empty value is given
+        self.assertEqual(HyperlinkDelegate.linkify_urls(input_output_text), input_output_text)
+
+    def test_linkify_urls_with_special_characters(self):
+        input_text = 'Check https://example.com/path?query=param&key=value'
+        expected_output = 'Check <a href="https://example.com/path?query=param&key=value">https://example.com/path?query=param&key=value</a>'
+        self.assertEqual(HyperlinkDelegate.linkify_urls(input_text), expected_output)
+
+    def test_linkify_urls_embedded_with_other_text(self):
+        input_text = 'Link in text:before https://example.com after:text'
+        expected_output = 'Link in text:before <a href="https://example.com">https://example.com</a> after:text'
+        self.assertEqual(HyperlinkDelegate.linkify_urls(input_text), expected_output)
+
+    def test_linkify_urls_with_complex_url(self):
+        input_text = 'Very link, much wow: http://www.test.com/path/to/embeded/location/many/pathsegments/?query=param&key=value#fragment'
+        expected_output = 'Very link, much wow: <a href="http://www.test.com/path/to/embeded/location/many/pathsegments/?query=param&key=value#fragment">http://www.test.com/path/to/embeded/location/many/pathsegments/?query=param&key=value#fragment</a>'
+        self.assertEqual(HyperlinkDelegate.linkify_urls(input_text), expected_output)
+
+    def test_format_html_single_line(self):
+        input_text = 'This is a test'
+        expected_output = '<p>This is a test</p>'
+        self.assertEqual(HyperlinkDelegate.format_html(input_text), expected_output)
+
+    def test_format_html_multiple_lines(self):
+        input_text = 'This is a test\nWith multiple lines\nFor formatting'
+        expected_output = '<p>This is a test<br/>With multiple lines<br/>For formatting</p>'
+        self.assertEqual(HyperlinkDelegate.format_html(input_text), expected_output)
+
+    def test_format_html_empty_string(self):
+        input_text = ''
+        expected_output = '<p></p>'
+        self.assertEqual(HyperlinkDelegate.format_html(input_text), expected_output)
+
+    def test_format_html_newline_only(self):
+        input_text = '\n\n'
+        expected_output = '<p><br/><br/></p>'
+        self.assertEqual(HyperlinkDelegate.format_html(input_text), expected_output)
+
+    def test_format_html_with_a_link_in_text(self):
+        input_text = 'This is a test\nWith multiple lines\nFor formatting\nhttps://example.com'
+        expected_output = '<p>This is a test<br/>With multiple lines<br/>For formatting<br/><a href="https://example.com">https://example.com</a></p>'
+        self.assertEqual(HyperlinkDelegate.format_html(input_text), expected_output)


### PR DESCRIPTION
Reddit's rate limiting has been a consistent issue since they were introduced, but it has been unclear to the user what issues are related to the rate limit.  The rate limits were (mostly) already caught and handled as part of the larger error handling scheme, but they were not handled individually and were not reported to the user in a meaningful way.  

This pull request fixes this lack of reporting and as a side effect of these fixes, adds new URL handling abilities in the output window.