### PR TITLE
Fix row count not updating on search

### DIFF
--- a/DownloaderForReddit/viewmodels/reddit_object_list_model.py
+++ b/DownloaderForReddit/viewmodels/reddit_object_list_model.py
@@ -33,7 +33,6 @@ class RedditObjectListModel(QAbstractListModel):
         self.list_type = list_type
         self.list = None
         self.reddit_objects = None
-        self.row_count = 0
 
         self.validator = None
         self.validation_thread = None
@@ -103,7 +102,6 @@ class RedditObjectListModel(QAbstractListModel):
                 f.filter(self.session, query=self.list.reddit_objects, order_by=order, desc=desc).all()
             self.refresh()
             self.check_last_added()
-            self.update_row_count(len(self.reddit_objects))
         except AttributeError:
             # AttributeError indicates that no list is set for this view model
             pass
@@ -226,7 +224,6 @@ class RedditObjectListModel(QAbstractListModel):
             self.session.commit()
             self.reddit_object_added.emit(item.id)
             self.last_added = item
-            self.update_row_count(self.row_count + 1)
             return True
         return False
 
@@ -236,7 +233,6 @@ class RedditObjectListModel(QAbstractListModel):
             self.list.reddit_objects.remove(self.list.reddit_objects[position])
         self.endRemoveRows()
         self.session.commit()
-        self.update_row_count(self.row_count - 1)
         return True
 
     def removeRow(self, row, parent=QModelIndex(), *args):
@@ -251,10 +247,6 @@ class RedditObjectListModel(QAbstractListModel):
             return len(self.reddit_objects) if self.reddit_objects else 0
         except AttributeError:
             return 0
-
-    def update_row_count(self, value):
-        self.row_count = value
-        self.count_change.emit(value)
 
     def data(self, index, role=Qt.DisplayRole):
         row = index.row()

--- a/DownloaderForReddit/viewmodels/reddit_object_list_model.py
+++ b/DownloaderForReddit/viewmodels/reddit_object_list_model.py
@@ -248,7 +248,7 @@ class RedditObjectListModel(QAbstractListModel):
 
     def rowCount(self, parent=QModelIndex(), *args, **kwargs):
         try:
-            return self.row_count
+            return len(self.reddit_objects) if self.reddit_objects else 0
         except AttributeError:
             return 0
 


### PR DESCRIPTION
Fix bug where the number of rows falls out of sync with the number of reddit objects in the GUI list when searching. 

# Before: 



https://github.com/user-attachments/assets/f31c3552-9b66-49b9-bc5b-e7fd46d66a0f



# After:

https://github.com/user-attachments/assets/c91cc049-6dd5-44c3-9bd0-97aa88ef7852

Test Build: https://github.com/zacker150/DownloaderForReddit/actions/runs/16854095313

