### PR TITLE
Fix AttributeError when post_sort_method is NULL

### DIFF
--- a/DownloaderForReddit/core/download_runner.py
+++ b/DownloaderForReddit/core/download_runner.py
@@ -368,7 +368,16 @@ class DownloadRunner(QObject):
                               and limit the submission generator.
         :return: A submission generator for the supplied praw object.
         """
+        from ..database.model_enums import PostSortMethod
         sort_method = reddit_object.post_sort_method
+        # Handle None case by falling back to default
+        if sort_method is None:
+            self.logger.warning(
+                f'post_sort_method is None for {reddit_object.object_type} {reddit_object.name}, '
+                f'using default PostSortMethod.NEW'
+            )
+            sort_method = PostSortMethod.NEW
+            reddit_object.post_sort_method = PostSortMethod.NEW
         if sort_method.value <= 4:
             submission_method = self.get_raw_submission_method(praw_object, sort_method.name.lower())
             return submission_method(limit=reddit_object.post_limit)


### PR DESCRIPTION
## Issue
Application crashes with `AttributeError: 'NoneType' object has no attribute 'value'` when downloading from users/subreddits that have NULL `post_sort_method` in the database.

## Root Cause
Database records with NULL `post_sort_method` (from legacy data or incomplete migrations) cause a crash at `download_runner.py:372` when the code attempts to access `.value` on None.

## Stack Trace
```
File "download_runner.py", line 372, in get_raw_submissions
AttributeError: 'NoneType' object has no attribute 'value'
```

## Full Stack Trace
```
{
    "levelname": "CRITICAL",
    "asctime": "11/07/2025 08:14:41 PM",
    "filename": "main.py",
    "module": "main",
    "name": "DownloaderForReddit.__main__",
    "funcName": "log_unhandled_exception",
    "lineno": 48,
    "message": "Unhandled exception",
    "exc_info": "Traceback (most recent call last):\n  File \"DownloaderForReddit\\core\\download_runner.py\", line 195, in run\n  File \"DownloaderForReddit\\core\\download_runner.py\", line 243, in run_download\n  File \"DownloaderForReddit\\core\\runner.py\", line 12, in check\n  File \"DownloaderForReddit\\core\\download_runner.py\", line 282, in get_reddit_object_submissions\n  File \"DownloaderForReddit\\core\\runner.py\", line 12, in check\n  File \"DownloaderForReddit\\core\\download_runner.py\", line 296, in get_user_submissions\n  File \"DownloaderForReddit\\core\\download_runner.py\", line 311, in handle_submissions\n  File \"DownloaderForReddit\\core\\runner.py\", line 12, in check\n  File \"DownloaderForReddit\\core\\download_runner.py\", line 336, in get_submissions\n  File \"DownloaderForReddit\\core\\download_runner.py\", line 372, in get_raw_submissions\nAttributeError: 'NoneType' object has no attribute 'value'"
}
```

## Solution
Add null check with fallback to `PostSortMethod.NEW` (the schema default) before accessing `sort_method.value`. The record is updated in-place to prevent future errors.

## Migration
No database migration required. NULL values are handled at runtime and auto-corrected on first access.

## Testing
Tested with database containing 163 NULL records. All downloads complete successfully with auto-correction.