### PR TITLE
Add search fallback for users with hidden profiles

### DIFF
--- a/DownloaderForReddit/core/content_runner.py
+++ b/DownloaderForReddit/core/content_runner.py
@@ -46,10 +46,14 @@ class ContentRunner(Runner):
                         self.hold = False
                         self.download_queue.put('RELEASE_HOLD')
                     else:
-                        extraction_type, extraction_object, significant_id = item
+                        extraction_type = item.extraction_type
+                        extraction_object = item.extraction_object
+                        significant_id = item.significant_id
+                        from_search_fallback = getattr(item, 'from_search_fallback', False)
                         if extraction_type == 'SUBMISSION':
                             future = self.executor.submit(self.handle_submission, submission=extraction_object,
-                                                          significant_id=significant_id)
+                                                          significant_id=significant_id,
+                                                          from_search_fallback=from_search_fallback)
                         else:
                             future = self.executor.submit(self.finish_post, post_id=extraction_object)
                         future.add_done_callback(self.remove_future)
@@ -68,15 +72,17 @@ class ContentRunner(Runner):
         self.futures.remove(future)
 
     @verify_run
-    def handle_submission(self, submission, significant_id):
+    def handle_submission(self, submission, significant_id, from_search_fallback=False):
         """
         Takes a reddit submission and creates a Post from its data.  Then calls the appropriate methods for the post.
         If comments are to be extracted from the submission, this is also handled here.
         :param submission: The reddit submission that is to be extracted.
         :param significant_id: The id of the reddit object for which the submissions was extracted from reddit.
+        :param from_search_fallback: Whether the submission was fetched via search fallback.
         """
         with self.db.get_scoped_session() as session:
-            post = SubmittableCreator.create_post(submission, significant_id, session, self.download_session_id)
+            post = SubmittableCreator.create_post(submission, significant_id, session, self.download_session_id,
+                                                  fetched_via_search=from_search_fallback)
             if post is not None:
                 submission_handler = SubmissionHandler(submission, post, self.download_session_id, session,
                                                        self.download_queue, self.stop_run)

--- a/DownloaderForReddit/core/download_runner.py
+++ b/DownloaderForReddit/core/download_runner.py
@@ -13,6 +13,7 @@ from DownloaderForReddit.core.download.downloader import Downloader
 from . import const
 from .content_runner import ContentRunner
 from .submission_filter import SubmissionFilter
+from .search_handler import SearchHandler
 from .runner import verify_run
 from .errors import NON_DOWNLOADABLE
 from ..database.models import DownloadSession, RedditObject, User, Subreddit, Post, Content
@@ -21,7 +22,8 @@ from ..messaging.message import Message
 from ..version import __version__
 
 
-ExtractionSet = namedtuple('ExtractionSet', 'extraction_type extraction_object significant_id')
+ExtractionSet = namedtuple('ExtractionSet', 'extraction_type extraction_object significant_id from_search_fallback')
+ExtractionSet.__new__.__defaults__ = (False,)  # Default from_search_fallback to False
 RunPair = namedtuple('RunPair', 'reddit_object_id praw_object')
 
 
@@ -50,6 +52,7 @@ class DownloadRunner(QObject):
         self.settings_manager = injector.get_settings_manager()
         self.reddit_instance = reddit_utils.get_reddit_instance()
         self.submission_filter = SubmissionFilter()
+        self.search_handler = SearchHandler(self.reddit_instance)
 
         self.user_id_list = user_id_list
         self.subreddit_id_list = subreddit_id_list
@@ -309,12 +312,39 @@ class DownloadRunner(QObject):
 
     def handle_submissions(self, reddit_object, praw_object):
         submissions = self.get_submissions(praw_object, reddit_object)
+        used_search_fallback = False
+        search_submission_ids = set()
+
+        # Check if search fallback should be triggered for users with hidden profiles
+        if reddit_object.object_type == 'USER':
+            should_fallback = self.search_handler.should_use_fallback(
+                profile_post_count=len(submissions),
+                user_setting=reddit_object.use_search_fallback,
+                global_setting=self.settings_manager.enable_search_fallback
+            )
+            if should_fallback:
+                Message.send_info(f'Profile access limited for {reddit_object.name}, using search fallback')
+                used_search_fallback = True
+                search_submissions, search_submission_ids = self.get_search_fallback_submissions(reddit_object)
+
+                # Merge submissions, avoiding duplicates
+                existing_ids = {s.id for s in submissions}
+                for sub in search_submissions:
+                    if sub.id not in existing_ids:
+                        submissions.append(sub)
+                        existing_ids.add(sub.id)
+
+        # Notify user if both profile and search returned no results
+        if len(submissions) == 0 and used_search_fallback:
+            Message.send_warning(f'No posts found for {reddit_object.name} via profile or search')
+
         date_limit = 0
         for submission in submissions:
             if submission.created > date_limit:
                 date_limit = submission.created
+            from_search = submission.id in search_submission_ids
             extraction_set = ExtractionSet(extraction_type='SUBMISSION', extraction_object=submission,
-                                           significant_id=reddit_object.id)
+                                           significant_id=reddit_object.id, from_search_fallback=from_search)
             self.submission_queue.put(extraction_set)
         if date_limit > 0:
             reddit_object.set_date_limit(date_limit)  # date limit modified after submissions are extracted
@@ -398,6 +428,43 @@ class DownloadRunner(QObject):
             return getattr(praw_object.submissions, sort_type)
         else:
             return getattr(praw_object, sort_type)
+
+    @verify_run
+    def get_search_fallback_submissions(self, reddit_object):
+        """
+        Retrieves submissions for a user via Reddit search API.
+        Used when direct profile access fails or returns insufficient results.
+
+        :param reddit_object: The User database object
+        :return: Tuple of (list of submissions, set of submission IDs from search)
+        """
+        submissions = []
+        search_submission_ids = set()
+
+        search_gen = self.search_handler.search_user_submissions(
+            username=reddit_object.name,
+            limit=self.settings_manager.search_fallback_post_limit
+        )
+
+        for submission in search_gen:
+            search_submission_ids.add(submission.id)
+
+            passes_date_limit = self.submission_filter.date_filter(submission, reddit_object)
+            if (submission.pinned or submission.stickied) or passes_date_limit:
+                if passes_date_limit:
+                    if (not self.filter_subreddits or
+                        submission.subreddit.display_name in self.validated_subreddits):
+                        if self.submission_filter.filter_submission(submission, reddit_object):
+                            submissions.append(submission)
+            else:
+                # Since search is sorted by new, we can break on old posts
+                break
+
+        self.logger.info(
+            f'Search fallback retrieved {len(submissions)} submissions for {reddit_object.name}'
+        )
+
+        return submissions, search_submission_ids
 
     def perpetuate_run(self):
         """

--- a/DownloaderForReddit/core/search_handler.py
+++ b/DownloaderForReddit/core/search_handler.py
@@ -1,0 +1,161 @@
+"""
+Downloader for Reddit takes a list of reddit users and subreddits and downloads content posted to reddit either by the
+users or on the subreddits.
+
+
+Copyright (C) 2017, Kyle Hickey
+
+
+This file is part of the Downloader for Reddit.
+
+Downloader for Reddit is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Downloader for Reddit is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Downloader for Reddit.  If not, see <http://www.gnu.org/licenses/>.
+"""
+
+import logging
+import prawcore
+from typing import Generator, Optional
+
+from praw.models import Submission
+
+from ..utils import injector
+from ..messaging.message import Message
+from . import const
+
+
+class SearchHandler:
+    """
+    Handles Reddit search API queries for fetching user submissions
+    when direct profile access fails or returns insufficient results.
+    """
+
+    def __init__(self, reddit_instance):
+        self.logger = logging.getLogger(f'DownloaderForReddit.{__name__}')
+        self.reddit = reddit_instance
+        self.settings = injector.get_settings_manager()
+
+    def search_user_submissions(
+        self,
+        username: str,
+        limit: Optional[int] = None,
+        time_filter: str = 'all'
+    ) -> Generator[Submission, None, None]:
+        """
+        Search for submissions by a specific user across Reddit.
+
+        :param username: The Reddit username to search for
+        :param limit: Maximum number of results (None for settings default)
+        :param time_filter: Time period to search ('all', 'year', 'month', etc.)
+        :return: Generator of praw Submission objects
+        """
+        if limit is None:
+            limit = self.settings.search_fallback_post_limit
+
+        query = f'author:{username}'
+
+        self.logger.info(
+            f'Initiating search fallback for user {username}',
+            extra={'query': query, 'limit': limit}
+        )
+
+        try:
+            subreddit = self.reddit.subreddit('all')
+            search_results = subreddit.search(
+                query,
+                sort='new',
+                time_filter=time_filter,
+                limit=limit
+            )
+
+            for submission in search_results:
+                # Verify the submission is actually from the target user
+                if self.verify_author(submission, username):
+                    yield submission
+
+        except prawcore.exceptions.TooManyRequests:
+            self.logger.error(
+                f'Rate limit reached during search fallback for {username}',
+                exc_info=True
+            )
+            message = (
+                f'Reddit rate limit reached during search fallback for: {username}.  '
+                f'Please try again shortly.\n'
+                f'For more information, please visit the link below:\n{const.RATE_LIMIT_DOC_URL}'
+            )
+            Message.send_error(message)
+            return
+
+        except prawcore.exceptions.RequestException:
+            self.logger.error(
+                f'Request failed during search fallback for {username}',
+                exc_info=True
+            )
+            Message.send_error(f'Search request failed for {username}')
+            return
+
+        except prawcore.exceptions.PrawcoreException as e:
+            self.logger.error(
+                f'PRAW error during search fallback for {username}: {type(e).__name__}',
+                exc_info=True
+            )
+            Message.send_error(f'Reddit API error during search for {username}')
+            return
+
+    def verify_author(self, submission: Submission, expected_username: str) -> bool:
+        """
+        Verify that a submission is actually from the expected author.
+
+        Reddit search can sometimes return unexpected results. This method
+        ensures we only process submissions from the target user.
+
+        :param submission: The praw Submission to verify
+        :param expected_username: The username we're searching for
+        :return: True if the submission author matches
+        """
+        try:
+            actual_author = submission.author.name.lower()
+            return actual_author == expected_username.lower()
+        except AttributeError:
+            # Author is deleted or inaccessible
+            self.logger.debug(
+                f'Could not verify author for submission {submission.id}'
+            )
+            return False
+
+    def should_use_fallback(
+        self,
+        profile_post_count: int,
+        user_setting: Optional[bool],
+        global_setting: bool
+    ) -> bool:
+        """
+        Determine if search fallback should be triggered.
+
+        :param profile_post_count: Number of posts retrieved from profile
+        :param user_setting: Per-user override (None=use global, True/False=override)
+        :param global_setting: Global enable_search_fallback setting
+        :return: True if fallback should be used
+        """
+        # Determine effective setting (per-user overrides global)
+        if user_setting is not None:
+            use_fallback = user_setting
+        else:
+            use_fallback = global_setting
+
+        if not use_fallback:
+            return False
+
+        threshold = self.settings.search_fallback_threshold
+
+        # Trigger fallback if profile returned fewer posts than threshold
+        return profile_post_count < threshold

--- a/DownloaderForReddit/core/submittable_creator.py
+++ b/DownloaderForReddit/core/submittable_creator.py
@@ -20,8 +20,8 @@ class SubmittableCreator:
         return cls.db
 
     @classmethod
-    def create_post(cls, submission: Submission, significant_id: int, session: Session, download_session_id: int) \
-            -> Optional[Post]:
+    def create_post(cls, submission: Submission, significant_id: int, session: Session, download_session_id: int,
+                    fetched_via_search: bool = False) -> Optional[Post]:
         post = None
         if cls.check_duplicate_post_url(submission.url, session):
             author = cls.get_author(submission, session)
@@ -42,7 +42,8 @@ class SubmittableCreator:
                 author=author,
                 subreddit=subreddit,
                 download_session_id=download_session_id,
-                significant_reddit_object_id=significant_id
+                significant_reddit_object_id=significant_id,
+                fetched_via_search=fetched_via_search
             )
             session.add(post)
             session.commit()

--- a/DownloaderForReddit/database/models.py
+++ b/DownloaderForReddit/database/models.py
@@ -280,6 +280,7 @@ class RedditObject(BaseModel):
     comment_save_structure = Column(String, default='%[post_author_name]/Comments/%[post_title]')
     custom_comment_save_path = Column(String, nullable=True)
     new = Column(Boolean, default=True)
+    use_search_fallback = Column(Boolean, nullable=True, default=None)  # None = use global, True/False = override
     lists = relationship(RedditObjectList, secondary='reddit_object_list_association', lazy='dynamic')
 
     object_type = Column(String(15))
@@ -570,6 +571,7 @@ class Post(BaseModel):
     extraction_error = Column(Enum(Error), nullable=True)
     error_message = Column(String, nullable=True)
     retry_attempts = Column(Integer, default=0)
+    fetched_via_search = Column(Boolean, nullable=False, default=False)  # True if post was fetched via search fallback
 
     author_id = Column(ForeignKey('user.id'))
     author = relationship('User', foreign_keys=author_id, backref='posts')

--- a/DownloaderForReddit/gui/settings/core_settings_widget.py
+++ b/DownloaderForReddit/gui/settings/core_settings_widget.py
@@ -1,5 +1,6 @@
 import os
-from PyQt5.QtWidgets import QFileDialog, QCheckBox, QListWidgetItem
+from PyQt5.QtWidgets import (QFileDialog, QCheckBox, QListWidgetItem, QGroupBox,
+                             QVBoxLayout, QHBoxLayout, QLabel, QSpinBox)
 from PyQt5.QtGui import QValidator
 from PyQt5.QtCore import Qt
 
@@ -25,6 +26,65 @@ class CoreSettingsWidget(AbstractSettingsWidget, Ui_CoreSettingsWidget):
         self.select_subreddit_base_directory_button.clicked.connect(
             lambda: self.select_directory_path(self.subreddit_save_dir_line_edit))
         self.extractor_map = {}
+        self.setup_search_fallback_settings()
+
+    def setup_search_fallback_settings(self):
+        """Add search fallback settings group box programmatically."""
+        # Create group box for search fallback settings
+        self.search_fallback_groupbox = QGroupBox('Search Fallback (Hidden Profiles)')
+        search_layout = QVBoxLayout(self.search_fallback_groupbox)
+        search_layout.setSpacing(10)
+
+        # Enable checkbox
+        enable_layout = QHBoxLayout()
+        enable_label = QLabel('Enable search fallback for users with hidden profiles:')
+        self.enable_search_fallback_checkbox = QCheckBox()
+        self.enable_search_fallback_checkbox.setToolTip(
+            'When enabled, if a user\'s profile returns few or no posts, '
+            'the app will search Reddit for their posts using author:username')
+        enable_layout.addWidget(enable_label)
+        enable_layout.addWidget(self.enable_search_fallback_checkbox)
+        enable_layout.addStretch()
+        search_layout.addLayout(enable_layout)
+
+        # Threshold spinbox
+        threshold_layout = QHBoxLayout()
+        threshold_label = QLabel('Trigger fallback when profile returns fewer than:')
+        self.search_fallback_threshold_spinbox = QSpinBox()
+        self.search_fallback_threshold_spinbox.setRange(1, 25)
+        self.search_fallback_threshold_spinbox.setToolTip(
+            'If the user\'s profile returns fewer posts than this number, '
+            'search fallback will be triggered')
+        threshold_posts_label = QLabel('posts')
+        threshold_layout.addWidget(threshold_label)
+        threshold_layout.addWidget(self.search_fallback_threshold_spinbox)
+        threshold_layout.addWidget(threshold_posts_label)
+        threshold_layout.addStretch()
+        search_layout.addLayout(threshold_layout)
+
+        # Post limit spinbox
+        limit_layout = QHBoxLayout()
+        limit_label = QLabel('Maximum posts to retrieve via search:')
+        self.search_fallback_limit_spinbox = QSpinBox()
+        self.search_fallback_limit_spinbox.setRange(10, 1000)
+        self.search_fallback_limit_spinbox.setToolTip(
+            'Maximum number of posts to retrieve when using search fallback')
+        limit_layout.addWidget(limit_label)
+        limit_layout.addWidget(self.search_fallback_limit_spinbox)
+        limit_layout.addStretch()
+        search_layout.addLayout(limit_layout)
+
+        # Connect enable checkbox to toggle other controls
+        self.enable_search_fallback_checkbox.toggled.connect(self.toggle_search_fallback_options)
+
+        # Add to the main layout (at the end, before the stretch)
+        self.verticalLayout_4.addWidget(self.search_fallback_groupbox)
+
+    def toggle_search_fallback_options(self):
+        """Enable/disable search fallback options based on the enable checkbox."""
+        enabled = self.enable_search_fallback_checkbox.isChecked()
+        self.search_fallback_threshold_spinbox.setEnabled(enabled)
+        self.search_fallback_limit_spinbox.setEnabled(enabled)
 
     def load_settings(self):
         self.user_save_dir_line_edit.setText(self.settings.user_save_directory)
@@ -51,6 +111,12 @@ class CoreSettingsWidget(AbstractSettingsWidget, Ui_CoreSettingsWidget):
                               self.multi_part_chunk_size_spinbox)
         self.multi_part_thread_count_spinbox.setValue(self.settings.multi_part_thread_count)
         self.load_extractor_list()
+
+        # Search fallback settings
+        self.enable_search_fallback_checkbox.setChecked(self.settings.enable_search_fallback)
+        self.search_fallback_threshold_spinbox.setValue(self.settings.search_fallback_threshold)
+        self.search_fallback_limit_spinbox.setValue(self.settings.search_fallback_post_limit)
+        self.toggle_search_fallback_options()
 
     def load_extractor_list(self):
         for extractor, enabled in self.settings.extractor_dict.items():
@@ -91,6 +157,11 @@ class CoreSettingsWidget(AbstractSettingsWidget, Ui_CoreSettingsWidget):
         self.settings.download_on_add = self.download_on_add_checkbox.isChecked()
         for extractor, checkbox in self.extractor_map.items():
             self.settings.extractor_dict[extractor] = checkbox.isChecked()
+
+        # Search fallback settings
+        self.settings.enable_search_fallback = self.enable_search_fallback_checkbox.isChecked()
+        self.settings.search_fallback_threshold = self.search_fallback_threshold_spinbox.value()
+        self.settings.search_fallback_post_limit = self.search_fallback_limit_spinbox.value()
 
     def select_directory_path(self, line_edit):
         text = line_edit.text()

--- a/DownloaderForReddit/gui/widgets/object_settings_widget.py
+++ b/DownloaderForReddit/gui/widgets/object_settings_widget.py
@@ -1,6 +1,7 @@
 import os
 from datetime import datetime
-from PyQt5.QtWidgets import QWidget, QMenu, QButtonGroup, QFileDialog
+from PyQt5.QtWidgets import (QWidget, QMenu, QButtonGroup, QFileDialog, QComboBox,
+                             QHBoxLayout, QLabel, QGroupBox, QVBoxLayout)
 from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QCursor
 
@@ -18,6 +19,7 @@ class ObjectSettingsWidget(QWidget, Ui_ObjectSettingsWidget):
         self.setupUi(self)
         self.settings_manager = injector.get_settings_manager()
         self.setup_widgets()
+        self.setup_search_fallback_widget()
         self.connect_edit_widgets()
         self.selected_objects = []
 
@@ -148,9 +150,40 @@ class ObjectSettingsWidget(QWidget, Ui_ObjectSettingsWidget):
             lambda: self.path_token_context_menu(self.duplicate_save_structure_line_edit)
         )
 
+    def setup_search_fallback_widget(self):
+        """Add search fallback settings for users with hidden profiles."""
+        # Create a group box for search fallback
+        self.search_fallback_groupbox = QGroupBox('Search Fallback (Hidden Profiles)')
+        search_layout = QVBoxLayout(self.search_fallback_groupbox)
+
+        # Create combo for tri-state selection
+        combo_layout = QHBoxLayout()
+        label = QLabel('Use search fallback:')
+        self.search_fallback_combo = QComboBox()
+        self.search_fallback_combo.addItem('Use Global Setting', None)
+        self.search_fallback_combo.addItem('Enable', True)
+        self.search_fallback_combo.addItem('Disable', False)
+        self.search_fallback_combo.setToolTip(
+            'When enabled, if this user\'s profile returns few or no posts, '
+            'the app will search Reddit for their posts using author:username.\n'
+            '"Use Global Setting" follows the setting in Core Settings.')
+        combo_layout.addWidget(label)
+        combo_layout.addWidget(self.search_fallback_combo)
+        combo_layout.addStretch()
+        search_layout.addLayout(combo_layout)
+
+        # Add to the main vertical layout (verticalLayout is inside verticalLayout_2)
+        self.verticalLayout.addWidget(self.search_fallback_groupbox)
+
     def connect_edit_widgets(self):
         self.setup_checkbox(self.lock_settings_checkbox, 'lock_settings')
         self.setup_checkbox(self.enable_download_checkbox, 'download_enabled')
+
+        # Search fallback combo connection
+        self.search_fallback_combo.currentIndexChanged.connect(
+            lambda x: self.set_object_value('use_search_fallback',
+                                            self.search_fallback_combo.itemData(x, Qt.UserRole))
+        )
         self.post_limit_spinbox.valueChanged.connect(lambda x: self.set_object_value('post_limit', x))
         self.score_limit_spinbox.valueChanged.connect(lambda x: self.set_object_value('post_score_limit', x))
         self.score_limit_operator_combo.currentIndexChanged.connect(
@@ -375,6 +408,27 @@ class ObjectSettingsWidget(QWidget, Ui_ObjectSettingsWidget):
         self.sync_line_edit(self.comment_save_path_structure_line_edit, 'comment_save_structure')
         self.sync_line_edit(self.custom_comment_save_path_line_edit, 'custom_comment_save_path')
         self.sync_comment_path_example()
+        self.sync_search_fallback()
+
+    def sync_search_fallback(self):
+        """Sync search fallback combo and visibility based on object type."""
+        # Only show for USER type, not SUBREDDIT
+        is_user = self.object_type == 'USER'
+        self.search_fallback_groupbox.setVisible(is_user)
+
+        if is_user:
+            self.sync_search_fallback_combo(self.search_fallback_combo, 'use_search_fallback')
+
+    def sync_search_fallback_combo(self, combo, attr):
+        """Sync a combo box that has None/True/False data values."""
+        value = self.get_value(attr)
+        # Find the item with matching data
+        for i in range(combo.count()):
+            if combo.itemData(i, Qt.UserRole) == value:
+                combo.setCurrentIndex(i)
+                return
+        # Default to first item (Use Global Setting = None)
+        combo.setCurrentIndex(0)
 
     def sync_optional(self):
         try:

--- a/DownloaderForReddit/persistence/settings_manager.py
+++ b/DownloaderForReddit/persistence/settings_manager.py
@@ -52,6 +52,11 @@ class SettingsManager:
         self.reddit_access = self.get('core', 'reddit_access', None)
         self.validate_names_before_add = self.get('core', 'validate_names_before_add', True)
 
+        # Search fallback settings (for users with hidden profiles)
+        self.enable_search_fallback = self.get('core', 'enable_search_fallback', False)
+        self.search_fallback_threshold = self.get('core', 'search_fallback_threshold', 3)
+        self.search_fallback_post_limit = self.get('core', 'search_fallback_post_limit', 500)
+
         default_extractor_dict = {
             extractor.__name__: True for extractor in BaseExtractor.__subclasses__()
         }

--- a/Tests/unittests/core/test_download_runner.py
+++ b/Tests/unittests/core/test_download_runner.py
@@ -348,3 +348,104 @@ class TestDownloadRunner(TestCase):
         get_raw_submissions.assert_called()
         self.assertEqual(0, len(submissions))
 
+    # =========================================================================
+    # Search Fallback Tests
+    # =========================================================================
+
+    def test_get_search_fallback_submissions_returns_tuple(self, reddit_utils):
+        """get_search_fallback_submissions should return (list, set) tuple."""
+        user = get_user(absolute_date_limit=self.now - timedelta(days=10))
+        mock_submissions = []
+        for x in range(3):
+            sub = MockPrawSubmission(created=self.now - timedelta(days=x), _id=f'search{x}')
+            sub.subreddit = MagicMock()
+            sub.subreddit.display_name = 'TestSub'
+            mock_submissions.append(sub)
+
+        download_runner = DownloadRunner()
+        download_runner.search_handler = MagicMock()
+        download_runner.search_handler.search_user_submissions.return_value = iter(mock_submissions)
+
+        result = download_runner.get_search_fallback_submissions(user)
+
+        self.assertIsInstance(result, tuple)
+        self.assertEqual(2, len(result))
+        submissions, ids = result
+        self.assertIsInstance(submissions, list)
+        self.assertIsInstance(ids, set)
+
+    def test_get_search_fallback_submissions_returns_submission_ids(self, reddit_utils):
+        """Search fallback should return set containing all searched submission IDs."""
+        user = get_user(absolute_date_limit=self.now - timedelta(days=10))
+        mock_submissions = []
+        for x in range(3):
+            sub = MockPrawSubmission(created=self.now - timedelta(days=x), _id=f'search{x}')
+            sub.subreddit = MagicMock()
+            sub.subreddit.display_name = 'TestSub'
+            mock_submissions.append(sub)
+
+        download_runner = DownloadRunner()
+        download_runner.search_handler = MagicMock()
+        download_runner.search_handler.search_user_submissions.return_value = iter(mock_submissions)
+
+        submissions, ids = download_runner.get_search_fallback_submissions(user)
+
+        self.assertEqual({'search0', 'search1', 'search2'}, ids)
+
+    def test_get_search_fallback_submissions_filters_by_date(self, reddit_utils):
+        """Search fallback should filter submissions by date limit."""
+        user = get_user(absolute_date_limit=self.now - timedelta(days=5))
+        mock_submissions = []
+        # 3 recent posts (within date limit)
+        for x in range(3):
+            sub = MockPrawSubmission(created=self.now - timedelta(days=x), _id=f'recent{x}')
+            sub.subreddit = MagicMock()
+            sub.subreddit.display_name = 'TestSub'
+            mock_submissions.append(sub)
+        # 2 old posts (outside date limit)
+        for x in range(10, 12):
+            sub = MockPrawSubmission(created=self.now - timedelta(days=x), _id=f'old{x}')
+            sub.subreddit = MagicMock()
+            sub.subreddit.display_name = 'TestSub'
+            mock_submissions.append(sub)
+
+        download_runner = DownloadRunner()
+        download_runner.search_handler = MagicMock()
+        download_runner.search_handler.search_user_submissions.return_value = iter(mock_submissions)
+
+        submissions, ids = download_runner.get_search_fallback_submissions(user)
+
+        # Should only include the 3 recent posts
+        self.assertEqual(3, len(submissions))
+
+    def test_get_search_fallback_submissions_respects_subreddit_filter(self, reddit_utils):
+        """Search fallback should respect subreddit filter when set."""
+        user = get_user(absolute_date_limit=self.now - timedelta(days=10))
+        allowed_sub = MagicMock()
+        allowed_sub.display_name = 'AllowedSub'
+        forbidden_sub = MagicMock()
+        forbidden_sub.display_name = 'ForbiddenSub'
+
+        mock_submissions = []
+        for x in range(3):
+            sub = MockPrawSubmission(created=self.now - timedelta(days=x), _id=f'allowed{x}')
+            sub.subreddit = allowed_sub
+            mock_submissions.append(sub)
+        for x in range(3, 6):
+            sub = MockPrawSubmission(created=self.now - timedelta(days=x), _id=f'forbidden{x}')
+            sub.subreddit = forbidden_sub
+            mock_submissions.append(sub)
+
+        download_runner = DownloadRunner()
+        download_runner.filter_subreddits = True
+        download_runner.validated_subreddits = ['AllowedSub']
+        download_runner.search_handler = MagicMock()
+        download_runner.search_handler.search_user_submissions.return_value = iter(mock_submissions)
+
+        submissions, ids = download_runner.get_search_fallback_submissions(user)
+
+        # Should only include submissions from AllowedSub
+        self.assertEqual(3, len(submissions))
+        for sub in submissions:
+            self.assertEqual('AllowedSub', sub.subreddit.display_name)
+

--- a/Tests/unittests/core/test_search_handler.py
+++ b/Tests/unittests/core/test_search_handler.py
@@ -1,0 +1,231 @@
+from unittest import TestCase
+from unittest.mock import patch, MagicMock, PropertyMock
+import logging
+import prawcore
+
+from DownloaderForReddit.core.search_handler import SearchHandler
+from DownloaderForReddit.utils import injector
+
+
+logging.disable(logging.CRITICAL)
+
+
+class TestSearchHandler(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.settings_manager = MagicMock()
+        cls.settings_manager.search_fallback_post_limit = 100
+        cls.settings_manager.search_fallback_threshold = 3
+        injector.settings_manager = cls.settings_manager
+
+    def setUp(self):
+        self.reddit_instance = MagicMock()
+        self.search_handler = SearchHandler(self.reddit_instance)
+
+    # =========================================================================
+    # Tests for should_use_fallback()
+    # =========================================================================
+
+    def test_should_use_fallback_disabled_globally(self):
+        """Fallback should not trigger when global setting is disabled."""
+        result = self.search_handler.should_use_fallback(
+            profile_post_count=0,
+            user_setting=None,
+            global_setting=False
+        )
+        self.assertFalse(result)
+
+    def test_should_use_fallback_enabled_globally_below_threshold(self):
+        """Fallback should trigger when enabled and profile returns fewer posts than threshold."""
+        result = self.search_handler.should_use_fallback(
+            profile_post_count=2,
+            user_setting=None,
+            global_setting=True
+        )
+        self.assertTrue(result)
+
+    def test_should_use_fallback_enabled_globally_at_threshold(self):
+        """Fallback should not trigger when profile returns exactly threshold posts."""
+        result = self.search_handler.should_use_fallback(
+            profile_post_count=3,  # equals threshold
+            user_setting=None,
+            global_setting=True
+        )
+        self.assertFalse(result)
+
+    def test_should_use_fallback_enabled_globally_above_threshold(self):
+        """Fallback should not trigger when profile returns more than threshold posts."""
+        result = self.search_handler.should_use_fallback(
+            profile_post_count=10,
+            user_setting=None,
+            global_setting=True
+        )
+        self.assertFalse(result)
+
+    def test_should_use_fallback_user_override_enables(self):
+        """User setting True should override global False."""
+        result = self.search_handler.should_use_fallback(
+            profile_post_count=0,
+            user_setting=True,
+            global_setting=False
+        )
+        self.assertTrue(result)
+
+    def test_should_use_fallback_user_override_disables(self):
+        """User setting False should override global True."""
+        result = self.search_handler.should_use_fallback(
+            profile_post_count=0,
+            user_setting=False,
+            global_setting=True
+        )
+        self.assertFalse(result)
+
+    def test_should_use_fallback_zero_posts_triggers(self):
+        """Fallback should trigger when profile returns zero posts."""
+        result = self.search_handler.should_use_fallback(
+            profile_post_count=0,
+            user_setting=None,
+            global_setting=True
+        )
+        self.assertTrue(result)
+
+    # =========================================================================
+    # Tests for verify_author()
+    # =========================================================================
+
+    def test_verify_author_matching(self):
+        """Should return True when author matches expected username."""
+        submission = MagicMock()
+        submission.author.name = 'TestUser'
+        result = self.search_handler.verify_author(submission, 'TestUser')
+        self.assertTrue(result)
+
+    def test_verify_author_case_insensitive(self):
+        """Author matching should be case-insensitive."""
+        submission = MagicMock()
+        submission.author.name = 'TestUser'
+        result = self.search_handler.verify_author(submission, 'testuser')
+        self.assertTrue(result)
+
+    def test_verify_author_non_matching(self):
+        """Should return False when author doesn't match."""
+        submission = MagicMock()
+        submission.author.name = 'OtherUser'
+        result = self.search_handler.verify_author(submission, 'TestUser')
+        self.assertFalse(result)
+
+    def test_verify_author_deleted(self):
+        """Should return False when author is deleted (None)."""
+        submission = MagicMock()
+        submission.author = None
+        result = self.search_handler.verify_author(submission, 'TestUser')
+        self.assertFalse(result)
+
+    def test_verify_author_no_name_attribute(self):
+        """Should return False when author has no name attribute."""
+        submission = MagicMock()
+        del submission.author.name
+        result = self.search_handler.verify_author(submission, 'TestUser')
+        self.assertFalse(result)
+
+    # =========================================================================
+    # Tests for search_user_submissions()
+    # =========================================================================
+
+    def test_search_user_submissions_success(self):
+        """Should yield submissions from search results."""
+        mock_submissions = [MagicMock() for _ in range(3)]
+        for i, sub in enumerate(mock_submissions):
+            sub.author.name = 'TestUser'
+            sub.id = f'sub{i}'
+
+        mock_subreddit = MagicMock()
+        mock_subreddit.search.return_value = iter(mock_submissions)
+        self.reddit_instance.subreddit.return_value = mock_subreddit
+
+        results = list(self.search_handler.search_user_submissions('TestUser', limit=10))
+
+        self.assertEqual(3, len(results))
+        self.reddit_instance.subreddit.assert_called_once_with('all')
+        mock_subreddit.search.assert_called_once_with(
+            'author:TestUser',
+            sort='new',
+            time_filter='all',
+            limit=10
+        )
+
+    def test_search_user_submissions_filters_wrong_author(self):
+        """Should filter out submissions from other authors."""
+        mock_sub1 = MagicMock()
+        mock_sub1.author.name = 'TestUser'
+        mock_sub2 = MagicMock()
+        mock_sub2.author.name = 'OtherUser'  # Wrong author
+        mock_sub3 = MagicMock()
+        mock_sub3.author.name = 'TestUser'
+
+        mock_subreddit = MagicMock()
+        mock_subreddit.search.return_value = iter([mock_sub1, mock_sub2, mock_sub3])
+        self.reddit_instance.subreddit.return_value = mock_subreddit
+
+        results = list(self.search_handler.search_user_submissions('TestUser'))
+
+        self.assertEqual(2, len(results))
+        self.assertNotIn(mock_sub2, results)
+
+    def test_search_user_submissions_uses_default_limit(self):
+        """Should use settings default when limit not specified."""
+        mock_subreddit = MagicMock()
+        mock_subreddit.search.return_value = iter([])
+        self.reddit_instance.subreddit.return_value = mock_subreddit
+
+        list(self.search_handler.search_user_submissions('TestUser'))
+
+        mock_subreddit.search.assert_called_once_with(
+            'author:TestUser',
+            sort='new',
+            time_filter='all',
+            limit=100  # From settings_manager mock
+        )
+
+    def test_search_user_submissions_rate_limit(self):
+        """Should handle rate limit exception gracefully."""
+        mock_subreddit = MagicMock()
+        mock_subreddit.search.side_effect = prawcore.exceptions.TooManyRequests(MagicMock())
+        self.reddit_instance.subreddit.return_value = mock_subreddit
+
+        results = list(self.search_handler.search_user_submissions('TestUser'))
+
+        self.assertEqual(0, len(results))
+
+    def test_search_user_submissions_request_exception(self):
+        """Should handle request exception gracefully."""
+        mock_subreddit = MagicMock()
+        mock_subreddit.search.side_effect = prawcore.exceptions.RequestException(
+            MagicMock(), MagicMock(), MagicMock()
+        )
+        self.reddit_instance.subreddit.return_value = mock_subreddit
+
+        results = list(self.search_handler.search_user_submissions('TestUser'))
+
+        self.assertEqual(0, len(results))
+
+    def test_search_user_submissions_prawcore_exception(self):
+        """Should handle generic prawcore exception gracefully."""
+        mock_subreddit = MagicMock()
+        mock_subreddit.search.side_effect = prawcore.exceptions.PrawcoreException()
+        self.reddit_instance.subreddit.return_value = mock_subreddit
+
+        results = list(self.search_handler.search_user_submissions('TestUser'))
+
+        self.assertEqual(0, len(results))
+
+    def test_search_user_submissions_empty_results(self):
+        """Should handle empty search results."""
+        mock_subreddit = MagicMock()
+        mock_subreddit.search.return_value = iter([])
+        self.reddit_instance.subreddit.return_value = mock_subreddit
+
+        results = list(self.search_handler.search_user_submissions('TestUser'))
+
+        self.assertEqual(0, len(results))

--- a/alembic/versions/9b863d496e96_add_search_fallback_columns.py
+++ b/alembic/versions/9b863d496e96_add_search_fallback_columns.py
@@ -1,0 +1,26 @@
+"""Add search fallback columns
+
+Revision ID: 9b863d496e96
+Revises: b838ef3372ca
+Create Date: 2026-01-27 18:30:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '9b863d496e96'
+down_revision = 'b838ef3372ca'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('reddit_object', sa.Column('use_search_fallback', sa.Boolean(), nullable=True))
+    op.add_column('post', sa.Column('fetched_via_search', sa.Boolean(), nullable=False, server_default='0'))
+
+
+def downgrade():
+    op.drop_column('post', 'fetched_via_search')
+    op.drop_column('reddit_object', 'use_search_fallback')


### PR DESCRIPTION
When a user's profile is hidden, the app can now fall back to Reddit's search API using author:username queries to find their submissions. Won't necessarily find all of the user's posts, but it's better than nothing at all.

Note that this was heavily vibe coded, so let me know if you want changes.

Features:
- Global setting to enable/disable search fallback (disabled by default)
- Per-user override setting (enable/disable/use global)
- Configurable threshold for triggering fallback
- Configurable maximum posts to retrieve via search (default 500)
- Posts fetched via search are tracked in the database

Requires database migration: 9b863d496e96_add_search_fallback_columns

Includes 23 new unit tests for SearchHandler and DownloadRunner