### PR TITLE
Fix Reddit Gallery Gif Downloads

### DIFF
--- a/DownloaderForReddit/extractors/reddit_uploads_extractor.py
+++ b/DownloaderForReddit/extractors/reddit_uploads_extractor.py
@@ -69,8 +69,8 @@ class RedditUploadsExtractor(BaseExtractor):
             for value in self.submission.media_metadata.values():
                 try:
                     container = value['s']
-                    url = container['u']
-                    ext = url[url.rfind('.') + 1: url.rfind('?width')]
+                    url = self.get_album_item_url(container)
+                    ext = self.get_media_extension(url)
                     media_id = getattr(value, 'id', None)
                     self.make_content(url, ext, count, media_id=media_id)
                     count += 1
@@ -83,6 +83,33 @@ class RedditUploadsExtractor(BaseExtractor):
                 message='Failed to extract images from reddit gallery',
                 log_exception=True,
             )
+
+    def get_album_item_url(self, container: dict) -> str:
+        """
+        The url for an album media item will be stored under a different key depending
+        on the type of media it is. This method returns the correct url for the media type.
+        :param container: The "container" dict for each media item in an album.
+        :return: The url to the media item.
+        """
+        keys = container.keys()
+        if 'mp4' in keys:
+            return container['mp4']
+        if 'gif' in keys:
+            return container['gif']
+        return container['u']
+
+    def get_media_extension(self, url: str) -> str:
+        """
+        Extracts the file extension from a URL using regex.
+        :param url: The URL to extract the extension from.
+        :return: The file extension if found, otherwise None.
+        """
+        match = re.search(r'\.([a-zA-Z0-9]+)(?=[?#]|$)', url)
+        url = match.group(1) if match else ''
+        # Reddit encodes gifs as mp4, so if the extension is shown as gif, we return mp4
+        if url == 'gif':
+            url = 'mp4'
+        return url
 
     def extract_single(self):
         if not self.url.endswith(const.ALL_EXT):

--- a/Tests/unittests/extractors/test_reddit_uploads_extractor.py
+++ b/Tests/unittests/extractors/test_reddit_uploads_extractor.py
@@ -1,0 +1,52 @@
+from unittest.mock import MagicMock
+
+from DownloaderForReddit.extractors import RedditUploadsExtractor
+from Tests.unittests.extractors.abstract_extractor_test import ExtractorTest
+
+
+class TestRedditUploadsExtractor(ExtractorTest):
+
+    def test_get_album_item_url_image(self):
+        test_url = 'https://preview.redd.it/w8k58f0hqstg1.jpg?width=640&format=pjpg&auto=webp&s=d21d6608b544946186602108e501ef096f614d80'
+        container_data = {
+            "y": 627,
+            "x": 640,
+            "u": test_url,
+        }
+
+        extractor = RedditUploadsExtractor(MagicMock())
+        url = extractor.get_album_item_url(container_data)
+        self.assertEqual(url, test_url)
+
+    def test_get_album_item_url_gif(self):
+        container_data = {
+            "y": 640,
+            "gif": "https://i.redd.it/6lqj0jhjqstg1.gif",
+            "mp4": "https://preview.redd.it/6lqj0jhjqstg1.gif?format=mp4&s=bd89b21b1a23f340cebb629a440517fd2226dd64",
+            "x": 360
+        }
+
+        extractor = RedditUploadsExtractor(MagicMock())
+        url = extractor.get_album_item_url(container_data)
+        self.assertEqual(url, 'https://preview.redd.it/6lqj0jhjqstg1.gif?format=mp4&s=bd89b21b1a23f340cebb629a440517fd2226dd64')
+
+    def test_get_media_extension_image(self):
+        test_url = 'https://preview.redd.it/w8k58f0hqstg1.jpg?width=640&format=pjpg&auto=webp&s=d21d6608b544946186602108e501ef096f614d80'
+
+        extractor = RedditUploadsExtractor(MagicMock())
+        ext = extractor.get_media_extension(test_url)
+        self.assertEqual(ext, 'jpg')
+
+    def test_get_media_extension_gif(self):
+        test_url = 'https://preview.redd.it/6lqj0jhjqstg1.gif?format=mp4&s=bd89b21b1a23f340cebb629a440517fd2226dd64'
+
+        extractor = RedditUploadsExtractor(MagicMock())
+        ext = extractor.get_media_extension(test_url)
+        self.assertEqual(ext, 'mp4')
+
+    def test_get_media_extension_mp4(self):
+        test_url = 'https://i.redd.it/6lqj0jhjqstg1.mp4#format=mp4&s=asd90fu0j234inmosdif0s9ufoi324joisdfkjllksd'
+
+        extractor = RedditUploadsExtractor(MagicMock())
+        ext = extractor.get_media_extension(test_url)
+        self.assertEqual(ext, 'mp4')


### PR DESCRIPTION
Files inside of gallery posts were being silently skipped when they were .gif or .mp4 files. This was caused by the extractor logic not accounting for the differences in the returned data structures between regular image files and 'animated' files.

This fix updates the `RedditUploadsExtractor` to account for this different format and extract .gif and .mp4 files correctly.

Closes #416